### PR TITLE
Add (failing) test for int param validation

### DIFF
--- a/t/path-parameters.t
+++ b/t/path-parameters.t
@@ -15,6 +15,7 @@ plugin OpenAPI => {url => "data://main/path-parameters.json"};
 my $t = Test::Mojo->new;
 
 $t->post_ok('/api/user/foo' => json => {})->status_is(400);
+$t->post_ok('/api/user/42a' => json => {})->status_is(400);
 $t->post_ok('/api/user/42' => json => {})->status_is(200)->json_is('/id', 42);
 
 done_testing;


### PR DESCRIPTION
Integer constraint on a path passes validation when given a string starting with a number

Test throws a warning (inside `JSON::Validator::OpenAPI`) and gives a status code of 200 despite containing a non-numeric

See:
https://github.com/jhthorsen/json-validator/issues/36
https://github.com/jhthorsen/json-validator/pull/37