### PR TITLE
tweak setting of status code in before_render hook

### DIFF
--- a/t/not_implemented_hook.t
+++ b/t/not_implemented_hook.t
@@ -15,11 +15,11 @@ $t->app->helper(
     my $spec = $c->openapi->spec;
     is($spec->{operationId}, 'dig', 'not_implemented got spec');
 
-    return {mocked => "yes"};
+    return {json => [{status => "passed"}], status => 201};
   }
 );
 
-$t->post_ok('/api/emulate')->status_is(200)->json_is({mocked => "yes"});
+$t->post_ok('/api/emulate')->status_is(201)->json_is([{status => "passed"}]);
 
 done_testing;
 


### PR DESCRIPTION
don't assume that the return struct is a HASH and instead expect a
list of two items to be returned from the called method (one of the
NOT_FOUND, EXCEPTION, NOT_IMPLEMENTED methods or the overridden
openapi.not_implemented helper). we can then pass on the returned
data structure without any risk of stomping on the status key if
that should already exist and we can now support more than HASHes
in the data returned from the openapi.not_implemented helper

tweak test to check for above change