### PR TITLE
More verbose error message when a Swagger path is not implemented

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -17,7 +17,13 @@ sub NOT_FOUND {
 }
 
 sub NOT_IMPLEMENTED {
-  +{json => {errors => [{message => 'Not implemented.', path => '/'}]}, status => 501};
+  my ($c, $args) = @_;
+  my $path = $c->req->url->path->to_string;
+  my $namespace = $args->{snapshot}->{namespace};
+  my $controller = $args->{snapshot}->{controller} || '';
+  my $nsCon = $namespace ? $namespace.'::'.$controller : $controller;
+  my $action = $args->{snapshot}->{action} || '';
+  +{json => {errors => [{message => "OpenAPI path '$path' not implemented in controller '$nsCon->$action'.", path => $path}]}, status => 501};
 }
 
 my $X_RE = qr{^x-};
@@ -120,7 +126,7 @@ sub _before_render {
 
   my $format = $c->stash('format') || 'json';
   my $res
-    = $args->{exception} ? EXCEPTION() : !$has_spec ? NOT_FOUND() : $c->openapi->not_implemented;
+    = $args->{exception} ? EXCEPTION() : !$has_spec ? NOT_FOUND() : $c->openapi->not_implemented($args, $path);
   %$args = %$res;
 }
 

--- a/t/autorender.t
+++ b/t/autorender.t
@@ -20,7 +20,7 @@ $t->get_ok('/api/die')->status_is(500)->json_is('/errors/0/message', 'Internal s
 # Not implemented
 $t->get_ok('/api/todo')->status_is(404)->json_is('/errors/0/message', 'Not found.');
 $t->post_ok('/api/todo' => json => ['invalid'])->status_is(501)
-  ->json_is('/errors/0/message', 'Not implemented.');
+  ->json_is('/errors/0/message', "OpenAPI path '/api/todo' not implemented in controller 'dummy->todo'.");
 
 # Implemented, but still Not found
 define_controller();


### PR DESCRIPTION
If one is not very keenly enlightened in Mojolicious, it is hard
to understand how namespaces and controllers and actions interact.

It is more difficult when such complexity is hidden behind a plugin.

Also it might not be obvious that the value in 'x-mojo-to' is appended
after a namespace and how that might horribly mangle the controller
lookups.

It is very helpful to get a clear error message when such things arise.
Telling clearly what Controller::Subroutine-combo was been looked for and
for which path.

This patch extends the NOT_IMPLEMENTED-error with a clear description
of the error.

Instead of a concise "Not implemented."-error
An error like this is returned:
"OpenAPI path '\/api\/v1\/auth' not implemented in controller
    'PatronStore::Controller::Api::V1::Authenticate->get'."

This will give much more ammunition in solving the outstanding issue
with no need of extensively debugging Mojolicious internals to come up
with a clear error description.