### PR TITLE
Add support for "securityDefinitions"

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI/Guides/Security.pod
+++ b/lib/Mojolicious/Plugin/OpenAPI/Guides/Security.pod
@@ -68,9 +68,9 @@ In this example, we have the "dummy" security handler:
       url      => "data://main/sec.json",
       security => {
         dummy => sub {
-          my ($c, $security, $next) = @_;
-          return $c->$next if $c->req->headers->authorization;
-          return $c->render(openapi => $security, status => 401);
+          my ($c, $definition, $scopes, $cb) = @_;
+          return $c->$cb() if $c->req->headers->authorization;
+          return $c->$cb('Authorization header not present');
         }
       }
     });
@@ -78,13 +78,23 @@ In this example, we have the "dummy" security handler:
 
   1;
 
-C<$c> is a L<Mojolicious::Controller> object. C<$security> is the in this case
-is just an empty array ref, but it will contain the value for "security" under
-the given HTTP method. C<$next> is the method you need to call, if this security
-check passed.
+C<$c> is a L<Mojolicious::Controller> object. C<$definition> is the security
+definition from C</securityDefinitions>. C<$scopes> is the Oauth scopes, which
+in this case is just an empty array ref, but it will contain the value for
+"security" under the given HTTP method.
 
-At any point, you can call L<Mojolicious::Controller/render> to prevent
-L<Mojolicious::Please::OpenAPI> from dispatching to your action.
+Call C<$cb> with C<undef> or no argument at all to indicate pass. Call C<$cb>
+with a defined value (usually a string) to indicate that the check has failed.
+When none of the sets of security restrictions are satisfied, the standard
+OpenAPI structure is built using the values passed to the callbacks as the
+messages and rendered to the client with a status of 401.
+
+Note that the callback must be called or the dispatch will hang.
+
+B<TODO>:
+If after all of the checks have been performed, no set of requirements are
+satisfied then the a 401 error will be rendered.  Any exceptions that are
+thrown will result in a 500 being rendered.
 
 The first thing in your code that you need to do is to load this plugin and the
 L</Specification>. See L<Mojolicious::Plugin::OpenAPI/register> for information

--- a/lib/Mojolicious/Plugin/OpenAPI/Guides/Security.pod
+++ b/lib/Mojolicious/Plugin/OpenAPI/Guides/Security.pod
@@ -1,0 +1,106 @@
+=head1 NAME
+
+Mojolicious::Plugin::OpenAPI::Guides::Security - How to secure your API
+
+=head1 OVERVIEW
+
+This guide will give you an introduction on how to use the security features
+in OpenAPI, together with L<Mojolicious::Plugin::OpenAPI>.
+
+Note that this is currently EXPERIMENTAL! Please let me know if you have any
+feedback. See
+L<https://github.com/jhthorsen/mojolicious-plugin-openapi/pull/40> for a
+complete discussion.
+
+=head1 TUTORIAL
+
+=head2 Specification
+
+Here is an example specification that use
+L<securityDefinitions|http://swagger.io/specification/#securityDefinitionsObject>
+and L<security|http://swagger.io/specification/#securityRequirementObject> from
+the OpenAPI spec:
+
+  {
+    "swagger": "2.0",
+    "info": { "version": "0.8", "title": "Super secure" },
+    "schemes": [ "https" ],
+    "basePath": "/api",
+    "securityDefinitions": {
+      "dummy": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "dummy"
+      }
+    },
+    "paths": {
+      "/protected": {
+        "post": {
+          "x-mojo-to": "super#secret_resource",
+          "security": [{"dummy": []}],
+          "parameters": [
+            { "in": "body", "name": "body", "schema": { "type": "object" } }
+          ],
+          "responses": {
+            "200": {"description": "Echo response", "schema": { "type": "object" }},
+            "401": {"description": "Sorry mate", "schema": { "type": "array" }}
+          }
+        }
+      }
+    }
+  }
+
+=head2 Application
+
+The specification above can be dispatched to handlers inside your
+L<Mojolicious> application. The do so, add the "security" key when loading the
+plugin, and reference the "securityDefinitions" name inside that to a callback.
+In this example, we have the "dummy" security handler:
+
+  package Myapp;
+  use Mojo::Base "Mojolicious";
+
+  sub startup {
+    my $app = shift;
+
+    $app->plugin(OpenAPI => {
+      url      => "data://main/sec.json",
+      security => {
+        dummy => sub {
+          my ($c, $security, $next) = @_;
+          return $c->$next if $c->req->headers->authorization;
+          return $c->render(openapi => $security, status => 401);
+        }
+      }
+    });
+  }
+
+  1;
+
+C<$c> is a L<Mojolicious::Controller> object. C<$security> is the in this case
+is just an empty array ref, but it will contain the value for "security" under
+the given HTTP method. C<$next> is the method you need to call, if this security
+check passed.
+
+At any point, you can call L<Mojolicious::Controller/render> to prevent
+L<Mojolicious::Please::OpenAPI> from dispatching to your action.
+
+The first thing in your code that you need to do is to load this plugin and the
+L</Specification>. See L<Mojolicious::Plugin::OpenAPI/register> for information
+about what the plugin config can be.
+
+See also L<Mojolicious::Plugin::OpenAPI/SYNOPSIS> for example
+L<Mojolicious::Lite> application.
+
+=head2 Controller
+
+Your controllers and actions are unchanged. The difference in behavior is that
+the action simply won't be called if you fail to pass the security tests.
+
+=head1 SEE ALSO
+
+L<Mojolicious::Plugin::OpenAPI>,
+L<https://openapis.org/specification>.
+
+=cut

--- a/t/security-disabled.t
+++ b/t/security-disabled.t
@@ -1,0 +1,66 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+
+use Mojolicious::Lite;
+post '/global' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 'checks disabled'});
+  },
+  'global';
+
+plugin OpenAPI => {url => 'data://main/sec.json'};
+
+my $t = Test::Mojo->new;
+$t->post_ok('/api/global' => json => {})->status_is(200)->json_is('/ok' => 'checks disabled');
+
+done_testing;
+
+__DATA__
+@@ sec.json
+{
+  "swagger": "2.0",
+  "info": { "version": "0.8", "title": "Pets" },
+  "schemes": [ "http" ],
+  "basePath": "/api",
+  "securityDefinitions": {
+    "fail1": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "fail1"
+    }
+  },
+  "security": [{"fail1": []}],
+  "paths": {
+    "/global": {
+      "post": {
+        "x-mojo-name": "global",
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "type": "object",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {
+            "required": ["message"],
+            "properties": {
+              "message": { "type": "string", "description": "Human readable description of the error" },
+              "path": { "type": "string", "description": "JSON pointer to the input data where the error occur" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/t/security.t
+++ b/t/security.t
@@ -1,0 +1,61 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+
+use Mojolicious::Lite;
+post '/protected' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 1});
+  },
+  'protected';
+
+plugin OpenAPI => {
+  url      => 'data://main/sec.json',
+  security => {
+    dummy => sub {
+      my ($c, $config, $next) = @_;
+      return $c->$next if $c->req->headers->authorization;
+      return $c->render(openapi => $config, status => 401);
+    },
+  },
+};
+
+my $t = Test::Mojo->new;
+$t->post_ok('/api/protected' => {Authorization => 42}, json => {})->status_is(200)
+  ->json_is('/ok' => 1);
+
+$t->post_ok('/api/protected' => json => {})->status_is(401)->json_is('' => []);
+
+done_testing;
+
+__DATA__
+@@ sec.json
+{
+  "swagger": "2.0",
+  "info": { "version": "0.8", "title": "Pets" },
+  "schemes": [ "http" ],
+  "basePath": "/api",
+  "securityDefinitions": {
+    "dummy": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "dummy"
+    }
+  },
+  "paths": {
+    "/protected": {
+      "post": {
+        "x-mojo-name": "protected",
+        "security": [{"dummy": []}],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "type": "array" }}
+        }
+      }
+    }
+  }
+}

--- a/t/security.t
+++ b/t/security.t
@@ -3,28 +3,165 @@ use Test::Mojo;
 use Test::More;
 
 use Mojolicious::Lite;
-post '/protected' => sub {
+post '/global' => sub {
   my $c = shift->openapi->valid_input or return;
   $c->reply->openapi(200 => {ok => 1});
   },
-  'protected';
+  'global';
 
+post '/simple' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 1});
+  },
+  'simple';
+
+post '/fail_or_pass' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 1});
+  },
+  'fail_or_pass';
+
+post '/fail_and_pass' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 1});
+  },
+  'fail_and_pass';
+
+post '/multiple_fail' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 1});
+  },
+  'multiple_fail';
+
+post '/multiple_and_fail' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 1});
+  },
+  'multiple_and_fail';
+
+post '/cache' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 1});
+  },
+  'cache';
+
+post '/die' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 1});
+  },
+  'die';
+
+our %checks;
 plugin OpenAPI => {
   url      => 'data://main/sec.json',
   security => {
-    dummy => sub {
-      my ($c, $config, $next) = @_;
-      return $c->$next if $c->req->headers->authorization;
-      return $c->render(openapi => $config, status => 401);
+    pass1 => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{pass1}++;
+      $c->$cb();
+    },
+    pass2 => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{pass2}++;
+      $c->$cb();
+    },
+    fail1 => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{fail1}++;
+
+      # this deferrment causes multiple_and_fail to report
+      # out of order unless order is carefully maintained
+      Mojo::IOLoop->next_tick(sub { $c->$cb('Failed fail1') });
+    },
+    fail2 => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{fail2}++;
+      $c->$cb('Failed fail2');
+    },
+    '~fail/escape' => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{'~fail/escape'}++;
+      $c->$cb('Failed ~fail/escape');
+    },
+    die => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{die}++;
+      die 'Argh!';
     },
   },
 };
 
 my $t = Test::Mojo->new;
-$t->post_ok('/api/protected' => {Authorization => 42}, json => {})->status_is(200)
-  ->json_is('/ok' => 1);
+{
+  local %checks;
+  $t->post_ok('/api/global' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {pass1 => 1}, 'expected checks occurred';
+}
 
-$t->post_ok('/api/protected' => json => {})->status_is(401)->json_is('' => []);
+{
+  local %checks;
+  $t->post_ok('/api/simple' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {pass2 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/fail_or_pass' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {fail1 => 1, pass1 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/fail_and_pass' => json => {})->status_is(401)
+    ->json_is({errors => [{message => 'Failed fail1', path => '/security/0/fail1'}]});
+  is_deeply \%checks, {fail1 => 1, pass1 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/multiple_fail' => json => {})->status_is(401)->json_is(
+    {
+      errors => [
+        {message => 'Failed fail1', path => '/security/0/fail1'},
+        {message => 'Failed fail2', path => '/security/1/fail2'}
+      ]
+    }
+  );
+  is_deeply \%checks, {fail1 => 1, fail2 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/multiple_and_fail' => json => {})->status_is(401)->json_is(
+    {
+      errors => [
+        {message => 'Failed fail1', path => '/security/0/fail1'},
+        {message => 'Failed fail2', path => '/security/0/fail2'}
+      ]
+    }
+  );
+  is_deeply \%checks, {fail1 => 1, fail2 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/fail_escape' => json => {})->status_is(401)
+    ->json_is(
+    {errors => [{message => 'Failed ~fail/escape', path => '/security/0/~0fail~1escape'}]});
+  is_deeply \%checks, {'~fail/escape' => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/cache' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {fail1 => 1, pass1 => 1, pass2 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/die' => json => {})->status_is(500)->json_has('/errors/0/message');
+  is_deeply \%checks, {die => 1}, 'expected checks occurred';
+}
 
 done_testing;
 
@@ -36,24 +173,203 @@ __DATA__
   "schemes": [ "http" ],
   "basePath": "/api",
   "securityDefinitions": {
-    "dummy": {
+    "pass1": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "dummy"
+    },
+    "pass2": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "dummy"
+    },
+    "fail1": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "dummy"
+    },
+    "fail2": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "dummy"
+    },
+    "~fail/escape": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "dummy"
+    },
+    "die": {
       "type": "apiKey",
       "name": "Authorization",
       "in": "header",
       "description": "dummy"
     }
   },
+  "security": [{"pass1": []}],
   "paths": {
-    "/protected": {
+    "/global": {
       "post": {
-        "x-mojo-name": "protected",
-        "security": [{"dummy": []}],
+        "x-mojo-name": "global",
         "parameters": [
           { "in": "body", "name": "body", "schema": { "type": "object" } }
         ],
         "responses": {
           "200": {"description": "Echo response", "schema": { "type": "object" }},
-          "401": {"description": "Sorry mate", "schema": { "type": "array" }}
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    },
+    "/simple": {
+      "post": {
+        "x-mojo-name": "simple",
+        "security": [{"pass2": []}],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    },
+    "/fail_or_pass": {
+      "post": {
+        "x-mojo-name": "fail_or_pass",
+        "security": [
+          {"fail1": []},
+          {"pass1": []}
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    },
+    "/fail_and_pass": {
+      "post": {
+        "x-mojo-name": "fail_and_pass",
+        "security": [
+          {
+            "fail1": [],
+            "pass1": []
+          }
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    },
+    "/multiple_fail": {
+      "post": {
+        "x-mojo-name": "multiple_fail",
+        "security": [
+          { "fail1": [] },
+          { "fail2": [] }
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    },
+    "/multiple_and_fail": {
+      "post": {
+        "x-mojo-name": "multiple_and_fail",
+        "security": [
+          {
+            "fail1": [],
+            "fail2": [] 
+          }
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    },
+    "/fail_escape": {
+      "post": {
+        "x-mojo-name": "fail_escape",
+        "security": [{"~fail/escape": []}],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    },
+    "/cache": {
+      "post": {
+        "x-mojo-name": "cache",
+        "security": [
+          {
+            "fail1": [],
+            "pass1": []
+          },
+          {
+            "pass1": [],
+            "pass2": []
+          }
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    },
+    "/die": {
+      "post": {
+        "x-mojo-name": "die",
+        "security": [
+          {"die": []},
+          {"pass1": []}
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "type": "object",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {
+            "required": ["message"],
+            "properties": {
+              "message": { "type": "string", "description": "Human readable description of the error" },
+              "path": { "type": "string", "description": "JSON pointer to the input data where the error occur" }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
I have no idea if this should be merged, so I thought you could vote/decide.

What do you think?

@kivilahtio
@chandwki

Sidenote to @chandwki: You can now look up the spec in `under()` 12baad9899f3870025e67d225fdc0ab8cd1ed3a4

Sidenote to @leejo: Would it be cool to make a helper/extension that would do OAuth2 using this logic?