### PR TITLE
Inherit path parameters

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -76,7 +76,10 @@ sub _add_routes {
       my $endpoint;
 
       $has_options = 1 if lc $http_method eq 'options';
-      $route_path = _route_path($path, $op_spec);
+      {
+        local $op_spec->{parameters} = [@parameters, @{$op_spec->{parameters} || []}];
+        $route_path = _route_path($path, $op_spec);
+      }
 
       die qq([OpenAPI] operationId "$op_spec->{operationId}" is not unique)
         if $op_spec->{operationId} and $uniq{o}{$op_spec->{operationId}}++;

--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -82,9 +82,6 @@ sub _add_routes {
         if $op_spec->{operationId} and $uniq{o}{$op_spec->{operationId}}++;
       die qq([OpenAPI] Route name "$name" is not unique.) if $name and $uniq{r}{$name}++;
 
-      if (@parameters) {
-        $op_spec->{parameters} = [@parameters, @{$op_spec->{parameters} || []}];
-      }
       if ($name and $endpoint = $route->root->find($name)) {
         $route->add_child($endpoint);
       }
@@ -94,7 +91,7 @@ sub _add_routes {
       }
 
       $endpoint->to(ref $to eq 'ARRAY' ? @$to : $to) if $to;
-      $endpoint->to({'openapi.op_path' => [$path, $http_method]});
+      $endpoint->to({'openapi.op_path' => [$path, $http_method], 'openapi.path_parameters' => \@parameters});
       warn "[OpenAPI] Add route $http_method $path (@{[$endpoint->render]})\n" if DEBUG;
     }
 
@@ -278,6 +275,7 @@ sub _validate {
   my $op_spec = $c->openapi->spec;
 
   # Write validated data to $c->validation->output
+  local $op_spec->{parameters} = [@{$c->stash('openapi.path_parameters')}, @{$op_spec->{parameters} || []}];
   my @errors = $self->_validator->validate_request($c, $op_spec, $c->validation->output);
 
   if (@errors) {


### PR DESCRIPTION
This patch allows per-path parameters without modifying the per-method parameters. This is better for documentation generation which, if the per-method parameters ARE modified, see duplicates of the per-path ones.

Note that localization is just to work around the JSON::Validator::OpenAPI::validate_request method without changing it. I would equally support allowing another argument to that method for passing per-path parameters, in which case this PR could easily be modified to pass the parameters that way rather than localizing them in.