### PR TITLE
improve handling of OPTIONS routes wrt security

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI/Guides/Security.pod
+++ b/lib/Mojolicious/Plugin/OpenAPI/Guides/Security.pod
@@ -91,15 +91,6 @@ messages and rendered to the client with a status of 401.
 
 Note that the callback must be called or the dispatch will hang.
 
-B<TODO>:
-If after all of the checks have been performed, no set of requirements are
-satisfied then the a 401 error will be rendered.  Any exceptions that are
-thrown will result in a 500 being rendered.
-
-The first thing in your code that you need to do is to load this plugin and the
-L</Specification>. See L<Mojolicious::Plugin::OpenAPI/register> for information
-about what the plugin config can be.
-
 See also L<Mojolicious::Plugin::OpenAPI/SYNOPSIS> for example
 L<Mojolicious::Lite> application.
 
@@ -107,6 +98,14 @@ L<Mojolicious::Lite> application.
 
 Your controllers and actions are unchanged. The difference in behavior is that
 the action simply won't be called if you fail to pass the security tests.
+
+=head2 Exempted routes
+
+All of the routes created by the plugin are protected by the security
+defintions with the following exemptions.  The base route that renders the
+spec/documentation is exempted.  Additionally, when a route does not define its
+own C<OPTIONS> handler a documentation endpoint is generated which is exempt as
+well.
 
 =head1 SEE ALSO
 

--- a/t/security.t
+++ b/t/security.t
@@ -15,6 +15,12 @@ post '/simple' => sub {
   },
   'simple';
 
+options '/options' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->reply->openapi(200 => {ok => 1});
+  },
+  'options';
+
 post '/fail_or_pass' => sub {
   my $c = shift->openapi->valid_input or return;
   $c->reply->openapi(200 => {ok => 1});
@@ -105,9 +111,24 @@ my $t = Test::Mojo->new;
 }
 
 {
+  # global does not define an options handler, so it gets the default
+  # which is allowed through the security
+  local %checks;
+  $t->options_ok('/api/global')->status_is(200);
+  is_deeply \%checks, {}, 'expected checks occurred';
+}
+
+{
   local %checks;
   $t->post_ok('/api/simple' => json => {})->status_is(200)->json_is('/ok' => 1);
   is_deeply \%checks, {pass2 => 1}, 'expected checks occurred';
+}
+
+{
+  # route defined with an options handler so it must use the defined security
+  local %checks;
+  $t->options_ok('/api/options' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {pass1 => 1}, 'expected checks occurred';
 }
 
 {
@@ -243,6 +264,19 @@ __DATA__
         }
       }
     },
+    "/options": {
+      "options": {
+        "x-mojo-name": "options",
+        "security": [{"pass1": []}],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }},
+          "401": {"description": "Sorry mate", "schema": { "$ref": "#/definitions/Error" }}
+        }
+      }
+    },
     "/fail_or_pass": {
       "post": {
         "x-mojo-name": "fail_or_pass",
@@ -299,7 +333,7 @@ __DATA__
         "security": [
           {
             "fail1": [],
-            "fail2": [] 
+            "fail2": []
           }
         ],
         "parameters": [


### PR DESCRIPTION
Given the new security architecture, the injected OPTIONS routes (useful
for documentation and (when clever) CORS) were no longer accessible.
This patch explicitly exempts these generated OPTIONS handlers. Perhaps
in the future if CORS handling is added this could be addressed more
robustly there.