### PR TITLE
fix spec rendering after JSON::Validator recent changes

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -165,9 +165,20 @@ sub _helper_spec {
     $op_path ||= $r->{'openapi.op_path'};
   }
 
-  return $spec->get($path) if $path;
-  return undef unless $op_path;
-  return $spec->data->{paths}{$op_path->[0]}{$op_path->[1]};
+  my $resolved_spec;
+  if ($path) {
+    $resolved_spec = $spec->get($path)
+  }
+  elsif ($op_path) {
+    $resolved_spec = $spec->data->{paths}{$op_path->[0]}{$op_path->[1]};
+  }
+  else {
+    return undef;
+  }
+
+  my $self = _self($c);
+  $resolved_spec = $self->_validator()->_explode($resolved_spec);
+  return $resolved_spec;
 }
 
 sub _log {


### PR DESCRIPTION
Recent changes in JSON::Validator lead to inability to read full route specification with spec helper. You can see details here https://github.com/jhthorsen/json-validator/issues/82

This PR tries to fix the issue and explode part of schema, which was requested with spec helper.