### PR TITLE
Specify minimum perl version (5.10)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,5 +16,6 @@ WriteMakefile(
   },
   BUILD_REQUIRES => {'Test::More'      => '0.88'},
   PREREQ_PM      => {'JSON::Validator' => '1.06', 'Mojolicious' => '6.40'},
+  MIN_PERL_VERSION => '5.10.0',
   test           => {TESTS             => (-e 'META.yml' ? 't/*.t' : 't/*.t xt/*.t')},
 );


### PR DESCRIPTION
This module is my [CPAN PR Challenge](http://cpan-prc.org/) assignment for December.

Starting gently, here is a minor addition to specify the minimum perl version. The use of defined-or (//) in lib/Mojolicious/Plugin/OpenAPI.pm sets this at 5.10.