### PR TITLE
Add helper openapi.spec_for_uri

### DIFF
--- a/t/spec.t
+++ b/t/spec.t
@@ -10,6 +10,14 @@ get '/spec' => sub {
   },
   'Spec';
 
+get '/specforuri' => sub {
+  my $c = shift->openapi->valid_input or return;
+  my $response = eval { $c->openapi->spec_for_uri('/api') };
+  $response = $@ ? { error => $@ } : $response;
+  $c->render(json => $response);
+  },
+  'Spec_for_uri';
+
 plugin OpenAPI => {url => 'data://main/spec.json'};
 
 my $t = Test::Mojo->new;
@@ -17,6 +25,9 @@ my $t = Test::Mojo->new;
 $t->get_ok('/api/spec')->status_is(200)
   ->json_is('/op_spec/responses/200/description', 'Spec response.')
   ->json_is('/info/version',                      '0.8');
+
+$t->get_ok('/api/specforuri')->status_is(200)
+  ->json_is('/swagger', '2.0');
 
 $t->options_ok('/api/spec')->status_is(200)->json_is('/get/operationId', 'Spec');
 $t->options_ok('/api/spec?method=get')->status_is(200)->json_is('/operationId', 'Spec');
@@ -48,6 +59,17 @@ __DATA__
         "parameters" : [
           { "in": "body", "name": "body", "schema": { "type" : "object" } }
         ],
+        "responses" : {
+          "200": {
+            "description": "Spec response.",
+            "schema": { "type": "object" }
+          }
+        }
+      }
+    },
+    "/specforuri" : {
+      "get" : {
+        "operationId" : "Spec_for_uri",
         "responses" : {
           "200": {
             "description": "Spec response.",


### PR DESCRIPTION
As you may have seen on `#mojo`, in an app's `startup` method, the app can't serve requests. Being able to access an OpenAPI server's spec during that time is critical for the GraphQL plugin.

The reason this is useful, is that `openapi.spec` et all, using the `_self` function, need to have a `tx` to get the URL for the current request. If you favour this, then I could also make `JSON::Validator->schema` use this technique when there is an `app` attribute set.