### PR TITLE
Add version check of yaml module when testing

### DIFF
--- a/t/yaml.t
+++ b/t/yaml.t
@@ -4,9 +4,10 @@ use Test::More;
 use Mojolicious;
 
 my $n = 0;
-for my $module (qw(YAML::XS)) {
-  unless (eval "require $module;1") {
-    diag "Skipping test when $module is not installed";
+my %modules = ('YAML::XS'=>'0.67');
+for my $module (keys %modules) {
+  unless (eval "use $module $modules{$module};1") {
+    diag "Skipping test when $module $modules{$module} is not installed"; 
     next;
   }
 


### PR DESCRIPTION
The JSON::Validator seems to require at least version 0.67 of YAML::XS
to work. If an older version is installed the the test fails. I've
changed the pre-condition to check for a specific version of YAML::XS,
and if it's not installed the test is skipped, just as if the modules
wasn't installed at all.

This should most/all of the CPAN Testers failures.

This is part of the CPAN Pull Request Challenge, where I got
Mojolicious::Plugin::OpenAPI as my February assignment.