### PR TITLE
fix default error template lookup by mode

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -140,6 +140,7 @@ sub _add_routes {
 
 sub _before_render {
   my ($c, $args) = @_;
+  return unless _self($c);
   my $handler = $args->{handler} || 'openapi';
 
   # Call _render() for response data

--- a/t/autorender.t
+++ b/t/autorender.t
@@ -16,6 +16,7 @@ my %inline;
 }
 
 my $t = Test::Mojo->new;
+$t->app->mode('development');
 
 # Exception
 $t->get_ok('/api/die')->status_is(500)->json_is('/errors/0/message', 'Internal Server Error.');
@@ -32,6 +33,9 @@ $t->post_ok('/api/todo')->status_is(200)->json_is('/todo', 42);
 
 # Custom Not Found response
 $t->get_ok('/api/not-found')->status_is(404)->json_is('/this_is_fine', 1);
+
+# Custom Not Found template (mode)
+$t->get_ok('/THIS_IS_NOT_FOUND')->status_is(404)->content_like(qr{Not found development});
 
 # Fallback to default renderer
 $inline{template} = 'inline';
@@ -101,3 +105,7 @@ __DATA__
 }
 @@ inline.html.ep
 Too cool
+@@ not_found.html.ep
+Not found
+@@ not_found.development.html.ep
+Not found development


### PR DESCRIPTION
By default, Mojolicious will first try to find
`not_found.$mode.$format.*` before trying `not_found.$format.*`.
Somehow, the plugin was preventing that, but adding back one of the
checks from v1.30 fixes it.

This fixes one of the problems that 2.00 causes in Yancy. See https://github.com/preaction/Yancy/issues/18 and http://www.cpantesters.org/cpan/report/0f7cb956-c4c9-11e8-8f89-a365089b717b This change fixes the `t/standalone.t` test failure.