### PR TITLE
Restore path-searching logic to fix #107

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -199,13 +199,11 @@ sub _helper_get_spec {
 
   return $self->validator->get($path) if ref $path or $path =~ m!^/! or !length $path;
 
-  my $jp;
-  for my $s (reverse @{$c->match->stack}) {
-    $jp ||= [paths => $s->{'openapi.path'}];
-  }
-
-  push @$jp, lc $c->req->method if $jp and $path ne 'for_path';    # Internal for now
-  return $jp ? $self->validator->get($jp) : undef;
+  my ($op_path) = grep $_, map $_->{'openapi.path'}, reverse @{$c->match->stack};
+  return undef if !$op_path;
+  my $jp = [paths => $op_path];
+  push @$jp, lc $c->req->method if $path ne 'for_path';    # Internal for now
+  return $self->validator->get($jp);
 }
 
 sub _helper_reply {

--- a/t/authenticate.t
+++ b/t/authenticate.t
@@ -15,7 +15,7 @@ my $auth = app->routes->under('/api')->to(
     return 1 if $c->param('unsafe_token');
 
     # not authenticated
-    $c->render(openapi => {message => 'not logged in'}, status => 401);
+    $c->render(openapi => {errors => [{message => 'not logged in'}]}, status => 401);
     return;
   }
 );
@@ -33,7 +33,7 @@ plugin OpenAPI => {route => $auth, url => 'data://main/api.json'};
 my $t = Test::Mojo->new;
 
 $t->get_ok('/api/login')->status_is(200)->json_is('/id', 123);
-$t->get_ok('/api/protected')->status_is(401)->json_is('/message', 'not logged in');
+$t->get_ok('/api/protected')->status_is(401)->json_is('/errors/0/message', 'not logged in');
 $t->get_ok('/api/protected?unsafe_token=1')->status_is(200)->json_is('/protected', 'secret');
 
 done_testing;
@@ -58,8 +58,7 @@ __DATA__
       "get": {
         "x-mojo-name": "protected",
         "responses": {
-          "200": { "description": "response", "schema": { "type": "object" } },
-          "401": { "description": "response", "schema": { "type": "object" } }
+          "200": { "description": "response", "schema": { "type": "object" } }
         }
       }
     }

--- a/t/authenticate.t
+++ b/t/authenticate.t
@@ -33,6 +33,7 @@ plugin OpenAPI => {route => $auth, url => 'data://main/api.json'};
 my $t = Test::Mojo->new;
 
 $t->get_ok('/api/login')->status_is(200)->json_is('/id', 123);
+$t->get_ok('/api')->status_is(401)->json_is('/errors/0/message', 'not logged in');
 $t->get_ok('/api/protected')->status_is(401)->json_is('/errors/0/message', 'not logged in');
 $t->get_ok('/api/protected?unsafe_token=1')->status_is(200)->json_is('/protected', 'secret');
 


### PR DESCRIPTION
Before the commit referred to in #107, the stack was being searched for the last entry that had the `openapi.[op_]path` set, and using that. That commit just used the last one, since an array-ref is always true. This PR restores that logic, which then works correctly with Yancy.