### PR TITLE
Fix spelling errors in documentation

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -597,7 +597,7 @@ specification is written in perl, instead of JSON or YAML.
 
 =head3 version_from_class
 
-Can be used to overriden C</info/version> in the API specification, from the
+Can be used to overridden C</info/version> in the API specification, from the
 return value from the C<VERSION()> method in C<version_from_class>.
 
 This will only have an effect if "version" is "0".

--- a/lib/Mojolicious/Plugin/OpenAPI/Cors.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Cors.pm
@@ -356,7 +356,7 @@ Default value is 1800.
 
 =head2 openapi_cors_type
 
-This stash varible is available inside the callback passed on to
+This stash variable is available inside the callback passed on to
 L</openapi.cors_exchange>. It will be either "preflighted", "real" or "simple".
 "real" is the type that comes after "preflighted" when the actual request
 is sent to the server, but with "Origin" header set.

--- a/lib/Mojolicious/Plugin/OpenAPI/Security.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Security.pm
@@ -184,7 +184,7 @@ the action simply won't be called if you fail to pass the security tests.
 =head2 Exempted routes
 
 All of the routes created by the plugin are protected by the security
-defintions with the following exemptions.  The base route that renders the
+definitions with the following exemptions.  The base route that renders the
 spec/documentation is exempted.  Additionally, when a route does not define its
 own C<OPTIONS> handler a documentation endpoint is generated which is exempt as
 well.


### PR DESCRIPTION
Detected automatically by the lintian tool whilst packaging this distribution for Debian