### PR TITLE
I want a less confusing response on GET "/api" from the example in the synopsis

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -349,14 +349,14 @@ Mojolicious::Plugin::OpenAPI - OpenAPI / Swagger plugin for Mojolicious
   }, "echo";
 
   # Load specification and start web server
-  plugin OpenAPI => {url => "data:///api.json"};
+  plugin OpenAPI => {url => "data:///spec.json"};
   app->start;
 
   __DATA__
-  @@ api.json
+  @@ spec.json
   {
     "swagger" : "2.0",
-    "info" : { "version": "0.8", "title" : "Pets" },
+    "info" : { "version": "0.8", "title" : "Echo Service" },
     "schemes" : [ "http" ],
     "basePath" : "/api",
     "paths" : {


### PR DESCRIPTION
Rename the embedded template, so "GET /api" and "GET /api.json" return the same output.
See #117 for background info.