### PR TITLE
Fix for v3 defaults

### DIFF
--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -60,7 +60,7 @@ sub validate_request {
 
   # v3 Content-Type
   if (my $body_schema = $schema->{requestBody}) {
-    push @errors, $self->_validate_request_body($c, $body_schema);
+    push @errors, $self->_validate_request_body($c, $body_schema, $input);
   }
 
   for my $p (@{$schema->{parameters} || []}) {
@@ -86,6 +86,8 @@ sub validate_request {
       $value = $self->_coerce_by_collection_format($value, $p);
     }
 
+    # v3 Content-Type
+    ($exists, $value) = (1, $p->{schema}{default}) if !$exists and exists $p->{schema};
     ($exists, $value) = (1, $p->{default}) if !$exists and exists $p->{default};
 
     if ($type and defined $value) {
@@ -300,18 +302,42 @@ sub _to_list {
   return ref $_[0] eq 'ARRAY' ? @{$_[0]} : $_[0] ? ($_[0]) : ();
 }
 
+# v3 only
 sub _validate_request_body {
-  my ($self, $c, $body_schema) = @_;
+  my ($self, $c, $body_schema, $input) = @_;
   my $ct = $c->req->headers->content_type // '';
 
   $ct =~ s!;.*$!!;
   if ($body_schema = $body_schema->{content}{$ct}) {
     my $body = $self->_get_request_data($c, $ct =~ /\bform\b/ ? 'formData' : 'body');
-    return $self->_validate_request_value($body_schema, body => $body);
+
+    $body = _instantiate_defaults($body, $body_schema->{schema});
+
+    warn "[OpenAPI] Validate body\n" if DEBUG;
+    $input->{body} = $body;
+    return $self->validate({body => $body}, $body_schema);
   }
 
   return JSON::Validator::E('/' => "No requestBody rules defined for Content-Type $ct.") if $ct;
   return JSON::Validator::E('/', 'Invalid Content-Type.');
+}
+
+# recursively instantiate defaults
+sub _instantiate_defaults {
+  my ($data, $schema) = @_;
+
+  # bottom of recursion
+  return $data unless $schema->{type} // '' eq 'object';
+
+  while(my ($p, $v) = each %{$schema->{properties} || {}}) {
+    if (!exists($data->{$p}) and exists($v->{default})) {
+      $data->{$p} = $v->{default};
+    }
+
+    # recurse
+    $data->{$p} = _instantiate_defaults($data->{$p}, $v);
+  }
+  return $data;
 }
 
 sub _validate_request_value {

--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -350,10 +350,8 @@ sub _instantiate_defaults {
       @$data[$i] = _instantiate_defaults(@$data[$i], $schema->{items});
     }
   }
-  else {    # bottom of recursion
-    return $data;
-  }
 
+  # bottom of recursion
   return $data;
 }
 

--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -68,14 +68,15 @@ sub register {
 sub _add_default_response {
   my ($self, $op_spec, $code) = @_;
   return if $op_spec->{responses}{$code};
-  my $name   = $self->{default_response_name};
+  my $name = $self->{default_response_name};
 
   if ($self->validator->version eq '3') {
-    my $ref = $self->validator->schema->data->{components}{schemas}{$name} ||= $self->_default_schema;
+    my $ref = $self->validator->schema->data->{components}{schemas}{$name}
+      ||= $self->_default_schema;
     my %schema = ('$ref' => "#/components/schemas/$name");
     tie %schema, 'JSON::Validator::Ref', $ref, $schema{'$ref'}, $schema{'$ref'};
-    $op_spec->{responses}{$code} = {description => 'Default response.',
-                                    content => {'*/*' => {schema => \%schema}}};
+    $op_spec->{responses}{$code}
+      = {description => 'Default response.', content => {'*/*' => {schema => \%schema}}};
   }
   else {
     my $ref = $self->validator->schema->data->{definitions}{$name} ||= $self->_default_schema;

--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -69,10 +69,20 @@ sub _add_default_response {
   my ($self, $op_spec, $code) = @_;
   return if $op_spec->{responses}{$code};
   my $name   = $self->{default_response_name};
-  my $ref    = $self->validator->schema->data->{definitions}{$name} ||= $self->_default_schema;
-  my %schema = ('$ref' => "#/definitions/$name");
-  tie %schema, 'JSON::Validator::Ref', $ref, $schema{'$ref'}, $schema{'$ref'};
-  $op_spec->{responses}{$code} = {description => 'Default response.', schema => \%schema};
+
+  if ($self->validator->version eq '3') {
+    my $ref = $self->validator->schema->data->{components}{schemas}{$name} ||= $self->_default_schema;
+    my %schema = ('$ref' => "#/components/schemas/$name");
+    tie %schema, 'JSON::Validator::Ref', $ref, $schema{'$ref'}, $schema{'$ref'};
+    $op_spec->{responses}{$code} = {description => 'Default response.',
+                                    content => {'*/*' => {schema => \%schema}}};
+  }
+  else {
+    my $ref = $self->validator->schema->data->{definitions}{$name} ||= $self->_default_schema;
+    my %schema = ('$ref' => "#/definitions/$name");
+    tie %schema, 'JSON::Validator::Ref', $ref, $schema{'$ref'}, $schema{'$ref'};
+    $op_spec->{responses}{$code} = {description => 'Default response.', schema => \%schema};
+  }
 }
 
 sub _add_routes {

--- a/t/v3-defaults.t
+++ b/t/v3-defaults.t
@@ -1,0 +1,132 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+
+use Mojolicious::Lite;
+
+plan skip_all => $@ unless eval 'use YAML::XS 0.67;1';
+
+post '/test' => sub {
+  my $c = shift->openapi->valid_input or return;
+
+  my $return_obj = {query  => $c->validation->param('querydefault'),
+                    body   => $c->validation->param('body'),
+                    header => $c->req->headers->header('headerdefault')};
+
+  $c->render(status => 200, openapi => $return_obj);
+  },
+  'File';
+
+plugin OpenAPI => {schema => 'v3', url => 'data://main/file.yaml'};
+
+my $t = Test::Mojo->new;
+
+$t->post_ok('/api/test', json => {})->status_is(200)
+  ->json_is('/query'  => '2')
+  ->json_is('/body/bodydefault'  => '7')
+  ->json_is('/body/subobject/bodydefault'  => Mojo::JSON->true)
+  ->json_is('/body/subobject/subsubobject/bodydefault'  => 'astring')
+  ->json_is('/header' => 'a');
+
+done_testing;
+
+package main;
+__DATA__
+@@ file.yaml
+openapi: 3.0.0
+info:
+  title: Test defaults
+  version: "1"
+servers:
+  - url: /api
+paths:
+  /test:
+    post:
+      operationId: File
+      parameters:
+        - $ref: "#/components/parameters/querydefault"
+        - $ref: "#/components/parameters/headerdefault"
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: "#/components/schemas/bodydefault"
+      responses:
+        "200":
+          description: description
+          content:
+            "*/*":
+              schema:
+                type: object
+                required:
+                  - query
+                  - header
+                  - body
+                properties:
+                  query:
+                    type: string
+                  header:
+                    type: string
+                  body:
+                    type: object
+components:
+  schemas:
+    DefaultResponse:
+      description: description
+      type: object
+      properties:
+        message:
+          type: string
+    bodydefault:
+      description: description
+      type: object
+      required:
+        - bodydefault
+        - subobject
+      properties:
+        bodydefault:
+          type: integer
+          default: 7
+        subobject:
+          type: object
+          required:
+            - bodydefault
+            - subsubobject
+          properties:
+            bodydefault:
+              type: boolean
+              default: true
+            subsubobject:
+              type: object
+              required:
+                - bodydefault
+              properties:
+                bodydefault:
+                  type: string
+                  default: astring
+  parameters:
+    querydefault:
+      name: querydefault
+      in: query
+      schema:
+        type: string
+        enum:
+          - 1
+          - 2
+        default: 2
+    headerdefault:
+      name: headerdefault
+      in: header
+      schema:
+        type: string
+        enum:
+          - a
+          - b
+        default: a
+  responses:
+    DefaultResponse:
+      description: description
+      content:
+        "*/*":
+          schema:
+            $ref: "#/components/schemas/DefaultResponse"

--- a/t/v3-defaults.t
+++ b/t/v3-defaults.t
@@ -9,11 +9,13 @@ plan skip_all => $@ unless eval 'use YAML::XS 0.67;1';
 post '/test' => sub {
   my $c = shift->openapi->valid_input or return;
 
-  my $return_obj = {querydefault    => $c->validation->param('querydefault'),
-                    querynodefault  => $c->validation->param('querynodefault'),
-                    headerdefault   => $c->req->headers->header('headerdefault'),
-                    headernodefault => $c->req->headers->header('headernodefault'),
-                    body            => $c->validation->param('body')};
+  my $return_obj = {
+    querydefault    => $c->validation->param('querydefault'),
+    querynodefault  => $c->validation->param('querynodefault'),
+    headerdefault   => $c->req->headers->header('headerdefault'),
+    headernodefault => $c->req->headers->header('headernodefault'),
+    body            => $c->validation->param('body')
+  };
 
   $c->render(status => 200, openapi => $return_obj);
   },
@@ -23,23 +25,21 @@ plugin OpenAPI => {schema => 'v3', url => 'data://main/file.yaml'};
 
 my $t = Test::Mojo->new;
 
-$t->post_ok('/api/test?querynodefault=1' => {headernodefault => 'b'},
-            json => {bodynodefault => 9,
-                     subobject => {subsubobject => {subarray => [{arraynodefault => 'z'},
-                                                                 {arraynodefault => 'x'}]}}})
-  ->status_is(200)
-  ->json_is('/querydefault'  => '2')
-  ->json_is('/querynodefault'  => '1')
-  ->json_is('/body/bodydefault'  => '7')
-  ->json_is('/body/bodynodefault'  => '9')
-  ->json_is('/body/subobject/bodydefault'  => Mojo::JSON->true)
-  ->json_is('/body/subobject/subsubobject/bodydefault'  => 'astring')
-  ->json_is('/body/subobject/subsubobject/subarray/0/arraynodefault'  => 'z')
-  ->json_is('/body/subobject/subsubobject/subarray/1/arraynodefault'  => 'x')
-  ->json_is('/body/subobject/subsubobject/subarray/0/arraydefault'  => 'arraystring')
-  ->json_is('/body/subobject/subsubobject/subarray/1/arraydefault'  => 'arraystring')
-  ->json_is('/headerdefault' => 'a')
-  ->json_is('/headernodefault' => 'b');
+$t->post_ok(
+  '/api/test?querynodefault=1' => {headernodefault => 'b'},
+  json                         => {
+    bodynodefault => 9,
+    subobject => {subsubobject => {subarray => [{arraynodefault => 'z'}, {arraynodefault => 'x'}]}}
+  }
+)->status_is(200)->json_is('/querydefault' => '2')->json_is('/querynodefault' => '1')
+  ->json_is('/body/bodydefault'           => '7')->json_is('/body/bodynodefault' => '9')
+  ->json_is('/body/subobject/bodydefault' => Mojo::JSON->true)
+  ->json_is('/body/subobject/subsubobject/bodydefault'               => 'astring')
+  ->json_is('/body/subobject/subsubobject/subarray/0/arraynodefault' => 'z')
+  ->json_is('/body/subobject/subsubobject/subarray/1/arraynodefault' => 'x')
+  ->json_is('/body/subobject/subsubobject/subarray/0/arraydefault'   => 'arraystring')
+  ->json_is('/body/subobject/subsubobject/subarray/1/arraydefault'   => 'arraystring')
+  ->json_is('/headerdefault' => 'a')->json_is('/headernodefault' => 'b');
 
 done_testing;
 


### PR DESCRIPTION
This PR does the following:

- Implements v3 schemata defaults handling for  query, header and body
- body defaults can occur in properties at any depth
- v3 default response handling is fixed. This was broken as the paths were hard-coded to v2 paths
- new test script to test all of this

The default response handling issue explains the problems I was having with v3 as I use the plugin default response machinery a lot and it was not finding the default responses because the path was assumed to be e.g. `#/definitions/...` which doesn't exist in v3.