### PR TITLE
Add support for /components/securitySchemes from OpenAPI 3.0 and add default response types

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -176,8 +176,20 @@ sub _build_route {
     $self->{route_prefix} = "$spec_route_name.";
   }
 
-  $self->{route_prefix} //= '';
-  $self->route($route);
+  my $resolved_spec;
+  if ($path) {
+    $resolved_spec = $spec->get($path)
+  }
+  elsif ($op_path) {
+    $resolved_spec = $spec->data->{paths}{$op_path->[0]}{$op_path->[1]};
+  }
+  else {
+    return undef;
+  }
+
+  my $self = _self($c);
+  $resolved_spec = $self->_validator()->_explode($resolved_spec);
+  return $resolved_spec;
 }
 
 sub _default_schema {

--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -65,33 +65,29 @@ sub register {
   $self;
 }
 
-sub _add_default_response_2 {
+sub _add_default_response {
   my ($self, $op_spec) = @_;
-  for my $code (@{$self->{default_response_codes}}) {
-    next if $op_spec->{responses}{$code};
+  my $name        = $self->{default_response_name};
+  my $schema_data = $self->validator->schema->data;
 
-    my $name   = $self->{default_response_name};
-    my $ref    = $self->validator->schema->data->{definitions}{$name} ||= $self->_default_schema;
-    my %schema = ('$ref' => "#/definitions/$name");
-    tie %schema, 'JSON::Validator::Ref', $ref, $schema{'$ref'}, $schema{'$ref'};
-    $op_spec->{responses}{$code} = {description => 'Default response.', schema => \%schema};
-  }
-}
+  my $ref
+    = $self->validator->version ge '3'
+    ? ($schema_data->{components}{responses}{$name} ||= $self->_default_schema)
+    : ($schema_data->{definitions}{$name} ||= $self->_default_schema);
 
-sub _add_default_response_3 {
-  my ($self, $op_spec) = @_;
-  my $root_spec    = $self->validator->get(['/']);
-  my $default_name = $self->{default_response_name};
-  my $ref          = $root_spec->{components}{responses}{$default_name} ||= {
-      description => 'default Mojolicious::Plugin::OpenAPI response',
-      content     => {'application/json' => {schema => $self->_default_schema}},
-  };
-  my %schema = ('$ref' => "#/components/responses/$default_name");
+  my %schema
+    = $self->validator->version ge '3'
+    ? ('$ref' => "#/components/responses/$name")
+    : ('$ref' => "#/definitions/$name");
+
   tie %schema, 'JSON::Validator::Ref', $ref, $schema{'$ref'}, $schema{'$ref'};
-
   for my $code (@{$self->{default_response_codes}}) {
-    next if $op_spec->{responses}{$code};
-    $op_spec->{responses}{$code} = \%schema;
+    if ($self->validator->version ge '3') {
+      $op_spec->{responses}{$code} ||= $self->_default_schema_v3(\%schema);
+    }
+    else {
+      $op_spec->{responses}{$code} ||= $self->_default_schema_v2(\%schema);
+    }
   }
 }
 
@@ -110,8 +106,8 @@ sub _add_routes {
     for my $http_method (sort keys %{$self->validator->get([paths => $openapi_path]) || {}}) {
       next if $http_method =~ $X_RE or $http_method eq 'parameters';
       my $op_spec = $self->validator->get([paths => $openapi_path => $http_method]);
-      my $name = $op_spec->{'x-mojo-name'} || $op_spec->{operationId};
-      my $to   = $op_spec->{'x-mojo-to'};
+      my $name    = $op_spec->{'x-mojo-name'} || $op_spec->{operationId};
+      my $to      = $op_spec->{'x-mojo-to'};
       my $r;
 
       $self->{parameters_for}{$openapi_path}{$http_method}
@@ -135,9 +131,7 @@ sub _add_routes {
         $r->name("$self->{route_prefix}$name") if $name;
       }
 
-      my $add_default_response_method = sprintf "_add_default_response_%s",
-        $self->validator->version;
-      $self->$add_default_response_method($op_spec, $_) for @{$self->{default_response_codes}};
+      $self->_add_default_response($op_spec);
 
       $r->to(ref $to eq 'ARRAY' ? @$to : $to) if $to;
       $r->to({'openapi.method' => $http_method});
@@ -186,8 +180,8 @@ sub _build_route {
     ? Mojo::URL->new($self->validator->get('/servers/0/url') || '/')->path->to_string
     : $self->validator->get('/basePath') || '/';
 
-  $route = $route->any($base_path) if $route and !$route->pattern->unparsed;
-  $route = $app->routes->any($base_path) unless $route;
+  $route     = $route->any($base_path) if $route and !$route->pattern->unparsed;
+  $route     = $app->routes->any($base_path) unless $route;
   $base_path = $self->validator->schema->data->{basePath} = $route->to_string;
   $base_path =~ s!/$!!;
 
@@ -216,6 +210,19 @@ sub _default_schema {
         }
       }
     }
+  };
+}
+
+sub _default_schema_v2 {
+  my ($self, $schema) = @_;
+  +{description => 'Default response.', schema => $schema};
+}
+
+sub _default_schema_v3 {
+  my ($self, $schema) = @_;
+  +{
+    description => 'default Mojolicious::Plugin::OpenAPI response',
+    content     => {'application/json' => {schema => $schema}},
   };
 }
 

--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -176,20 +176,8 @@ sub _build_route {
     $self->{route_prefix} = "$spec_route_name.";
   }
 
-  my $resolved_spec;
-  if ($path) {
-    $resolved_spec = $spec->get($path)
-  }
-  elsif ($op_path) {
-    $resolved_spec = $spec->data->{paths}{$op_path->[0]}{$op_path->[1]};
-  }
-  else {
-    return undef;
-  }
-
-  my $self = _self($c);
-  $resolved_spec = $self->_validator()->_explode($resolved_spec);
-  return $resolved_spec;
+  $self->{route_prefix} //= '';
+  $self->route($route);
 }
 
 sub _default_schema {

--- a/lib/Mojolicious/Plugin/OpenAPI/Security.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Security.pm
@@ -1,11 +1,13 @@
 package Mojolicious::Plugin::OpenAPI::Security;
 use Mojo::Base -base;
 
+my %DEF_PATH = (2 => '/securityDefinitions', 3 => '/components/securitySchemes');
+
 sub register {
   my ($self, $app, $openapi, $config) = @_;
   my $handlers = $config->{security} or return;
 
-  return unless $openapi->validator->get('/securityDefinitions');
+  return unless $openapi->validator->get($DEF_PATH{$openapi->validator->version});
   return $openapi->route(
     $openapi->route->under('/')->to(cb => $self->_build_action($openapi, $handlers)));
 }
@@ -13,7 +15,7 @@ sub register {
 sub _build_action {
   my ($self, $openapi, $handlers) = @_;
   my $global      = $openapi->validator->get('/security') || [];
-  my $definitions = $openapi->validator->get('/securityDefinitions');
+  my $definitions = $openapi->validator->get($DEF_PATH{$openapi->validator->version});
 
   return sub {
     my $c = shift;

--- a/t/v2-security.t
+++ b/t/v2-security.t
@@ -1,0 +1,400 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+
+use Mojolicious::Lite;
+post '/global' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => {ok => 1});
+  },
+  'global';
+
+post('/fail_escape' => sub { shift->render(openapi => {ok => 1}) }, 'fail_escape');
+
+post '/simple' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => {ok => 1});
+  },
+  'simple';
+
+options '/options' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => {ok => 1});
+  },
+  'options';
+
+post '/fail_or_pass' => sub {
+  my $c = shift->openapi->valid_input or return;
+  die 'Could not connect to dummy database error message' if $ENV{DUMMY_DB_ERROR};
+  $c->render(openapi => {ok => 1});
+  },
+  'fail_or_pass';
+
+post '/fail_and_pass' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => {ok => 1});
+  },
+  'fail_and_pass';
+
+post '/multiple_fail' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => {ok => 1});
+  },
+  'multiple_fail';
+
+post '/multiple_and_fail' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => {ok => 1});
+  },
+  'multiple_and_fail';
+
+post '/cache' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => {ok => 1});
+  },
+  'cache';
+
+post '/die' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => {ok => 1});
+  },
+  'die';
+
+our %checks;
+plugin OpenAPI => {
+  url      => 'data://main/sec.json',
+  security => {
+    pass1 => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{pass1}++;
+      $c->$cb;
+    },
+    pass2 => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{pass2}++;
+      $c->$cb;
+    },
+    fail1 => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{fail1}++;
+
+      # This deferment causes multiple_and_fail to report
+      # out of order unless order is carefully maintained
+      Mojo::IOLoop->next_tick(sub { $c->$cb('Failed fail1') });
+    },
+    fail2 => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{fail2}++;
+      my %res = %$def;
+      $res{message} = 'Failed fail2';
+      $c->$cb(\%res);
+    },
+    '~fail/escape' => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{'~fail/escape'}++;
+      $c->$cb('Failed ~fail/escape');
+    },
+    die => sub {
+      my ($c, $def, $scopes, $cb) = @_;
+      $checks{die}++;
+      die 'Argh!';
+    },
+  },
+};
+
+my %security_definition
+  = (description => 'fail2', in => 'header', name => 'Authorization', type => 'apiKey');
+
+my $t = Test::Mojo->new;
+
+{
+  local %checks;
+  $t->post_ok('/api/global' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {pass1 => 1}, 'expected checks occurred';
+}
+
+{
+  # global does not define an options handler, so it gets the default
+  # which is allowed through the security
+  local %checks;
+  $t->options_ok('/api/global')->status_is(200);
+  is_deeply \%checks, {}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/simple' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {pass2 => 1}, 'expected checks occurred';
+}
+
+{
+  # route defined with an options handler so it must use the defined security
+  local %checks;
+  $t->options_ok('/api/options' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {pass1 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/fail_or_pass' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {fail1 => 1, pass1 => 1}, 'expected checks occurred';
+}
+
+{
+  local $ENV{DUMMY_DB_ERROR} = 1;
+  $t->post_ok('/api/fail_or_pass' => json => {})->status_is(500)
+    ->json_is('/errors/0/message', 'Internal Server Error.')->json_is('/errors/0/path', '/');
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/fail_and_pass' => json => {})->status_is(401)
+    ->json_is({errors => [{message => 'Failed fail1', path => '/security/0/fail1'}]});
+  is_deeply \%checks, {fail1 => 1, pass1 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/multiple_fail' => json => {})->status_is(401)->json_is(
+    {
+      errors => [
+        {message => 'Failed fail1', path => '/security/0/fail1'},
+        {message => 'Failed fail2', %security_definition},
+      ]
+    }
+  );
+  is_deeply \%checks, {fail1 => 1, fail2 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/multiple_and_fail' => json => {})->status_is(401)->json_is(
+    {
+      errors => [
+        {message => 'Failed fail1', path => '/security/0/fail1'},
+        {message => 'Failed fail2', %security_definition}
+      ]
+    }
+  );
+  is_deeply \%checks, {fail1 => 1, fail2 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/fail_escape' => json => {})->status_is(401)
+    ->json_is(
+    {errors => [{message => 'Failed ~fail/escape', path => '/security/0/~0fail~1escape'}]});
+  is_deeply \%checks, {'~fail/escape' => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/cache' => json => {})->status_is(200)->json_is('/ok' => 1);
+  is_deeply \%checks, {fail1 => 1, pass1 => 1, pass2 => 1}, 'expected checks occurred';
+}
+
+{
+  local %checks;
+  $t->post_ok('/api/die' => json => {})->status_is(500)->json_has('/errors/0/message');
+  is_deeply \%checks, {die => 1}, 'expected checks occurred';
+}
+
+done_testing;
+
+__DATA__
+@@ sec.json
+{
+  "swagger": "2.0",
+  "info": { "version": "0.8", "title": "Pets" },
+  "schemes": [ "http" ],
+  "basePath": "/api",
+  "securityDefinitions": {
+    "pass1": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "pass1"
+    },
+    "pass2": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "pass2"
+    },
+    "fail1": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "fail1"
+    },
+    "fail2": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "fail2"
+    },
+    "~fail/escape": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "dummy"
+    },
+    "die": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "description": "die"
+    }
+  },
+  "security": [{"pass1": []}],
+  "paths": {
+    "/global": {
+      "post": {
+        "x-mojo-name": "global",
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    },
+    "/simple": {
+      "post": {
+        "x-mojo-name": "simple",
+        "security": [{"pass2": []}],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    },
+    "/options": {
+      "options": {
+        "x-mojo-name": "options",
+        "security": [{"pass1": []}],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    },
+    "/fail_or_pass": {
+      "post": {
+        "x-mojo-name": "fail_or_pass",
+        "security": [
+          {"fail1": []},
+          {"pass1": []}
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    },
+    "/fail_and_pass": {
+      "post": {
+        "x-mojo-name": "fail_and_pass",
+        "security": [
+          {
+            "fail1": [],
+            "pass1": []
+          }
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    },
+    "/multiple_fail": {
+      "post": {
+        "x-mojo-name": "multiple_fail",
+        "security": [
+          { "fail1": [] },
+          { "fail2": [] }
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    },
+    "/multiple_and_fail": {
+      "post": {
+        "x-mojo-name": "multiple_and_fail",
+        "security": [
+          {
+            "fail1": [],
+            "fail2": []
+          }
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    },
+    "/fail_escape": {
+      "post": {
+        "x-mojo-name": "fail_escape",
+        "security": [{"~fail/escape": []}],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    },
+    "/cache": {
+      "post": {
+        "x-mojo-name": "cache",
+        "security": [
+          {
+            "fail1": [],
+            "pass1": []
+          },
+          {
+            "pass1": [],
+            "pass2": []
+          }
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    },
+    "/die": {
+      "post": {
+        "x-mojo-name": "die",
+        "security": [
+          {"die": []},
+          {"pass1": []}
+        ],
+        "parameters": [
+          { "in": "body", "name": "body", "schema": { "type": "object" } }
+        ],
+        "responses": {
+          "200": {"description": "Echo response", "schema": { "type": "object" }}
+        }
+      }
+    }
+  }
+}
+

--- a/t/v3-security.t
+++ b/t/v3-security.t
@@ -2,7 +2,12 @@ use Mojo::Base -strict;
 use Test::Mojo;
 use Test::More;
 
+BEGIN {
+  plan skip_all => $@ unless eval 'use YAML::XS 0.67;1';
+}
+
 use Mojolicious::Lite;
+
 post '/global' => sub {
   my $c = shift->openapi->valid_input or return;
   $c->render(openapi => {ok => 1});
@@ -63,6 +68,7 @@ post '/die' => sub {
 our %checks;
 plugin OpenAPI => {
   url      => 'data://main/sec.json',
+  schema   => 'v3',
   security => {
     pass1 => sub {
       my ($c, $def, $scopes, $cb) = @_;
@@ -204,46 +210,79 @@ done_testing;
 __DATA__
 @@ sec.json
 {
-  "swagger": "2.0",
+  "openapi": "3.0.0",
   "info": { "version": "0.8", "title": "Pets" },
-  "schemes": [ "http" ],
-  "basePath": "/api",
-  "securityDefinitions": {
-    "pass1": {
-      "type": "apiKey",
-      "name": "Authorization",
-      "in": "header",
-      "description": "pass1"
+  "servers": [
+    { "url": "http://petstore.swagger.io/api" }
+  ],
+  "components": {
+    "responses": {
+      "defaultResponse": {
+        "description": "default response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "errors": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "message": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["message"]
+                  }
+                }
+              },
+              "required": ["errors"]
+            }
+          }
+        }
+      }
     },
-    "pass2": {
-      "type": "apiKey",
-      "name": "Authorization",
-      "in": "header",
-      "description": "pass2"
-    },
-    "fail1": {
-      "type": "apiKey",
-      "name": "Authorization",
-      "in": "header",
-      "description": "fail1"
-    },
-    "fail2": {
-      "type": "apiKey",
-      "name": "Authorization",
-      "in": "header",
-      "description": "fail2"
-    },
-    "~fail/escape": {
-      "type": "apiKey",
-      "name": "Authorization",
-      "in": "header",
-      "description": "dummy"
-    },
-    "die": {
-      "type": "apiKey",
-      "name": "Authorization",
-      "in": "header",
-      "description": "die"
+    "securitySchemes": {
+      "pass1": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "pass1"
+      },
+      "pass2": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "pass2"
+      },
+      "fail1": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "fail1"
+      },
+      "fail2": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "fail2"
+      },
+      "~fail/escape": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "dummy"
+      },
+      "die": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "die"
+      }
     }
   },
   "security": [{"pass1": []}],
@@ -251,11 +290,19 @@ __DATA__
     "/global": {
       "post": {
         "x-mojo-name": "global",
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     },
@@ -263,11 +310,19 @@ __DATA__
       "post": {
         "x-mojo-name": "simple",
         "security": [{"pass2": []}],
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     },
@@ -275,11 +330,19 @@ __DATA__
       "options": {
         "x-mojo-name": "options",
         "security": [{"pass1": []}],
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     },
@@ -290,11 +353,19 @@ __DATA__
           {"fail1": []},
           {"pass1": []}
         ],
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     },
@@ -307,11 +378,19 @@ __DATA__
             "pass1": []
           }
         ],
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     },
@@ -322,11 +401,19 @@ __DATA__
           { "fail1": [] },
           { "fail2": [] }
         ],
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     },
@@ -339,11 +426,19 @@ __DATA__
             "fail2": []
           }
         ],
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     },
@@ -351,11 +446,19 @@ __DATA__
       "post": {
         "x-mojo-name": "fail_escape",
         "security": [{"~fail/escape": []}],
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     },
@@ -372,11 +475,19 @@ __DATA__
             "pass2": []
           }
         ],
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     },
@@ -387,11 +498,19 @@ __DATA__
           {"die": []},
           {"pass1": []}
         ],
-        "parameters": [
-          { "in": "body", "name": "body", "schema": { "type": "object" } }
-        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Echo response", "schema": { "type": "object" }}
+          "200": {"description": "Echo response", "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }}
         }
       }
     }


### PR DESCRIPTION
This PR 
1. Fixes bug with default_response_codes - Response object format changed between 2.0 and 3.0, so we need to add different type of response objects for 3.0 routes. I changed logic and used v3 default response feature. Maybe you'll find it not an appropriate solution, but it's easy to use my code to implement same logic both for 3.0 and 2.0 routes.

2. Adds support for 3.0 to Security Plugin.