### PR TITLE
Fix failing renderer.t test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ perl:
 env:
   - "HARNESS_OPTIONS=j6"
 install:
-  - "cpanm -n Test::Pod Test::Pod::Coverage Data::Validate::Domain Data::Validate::IP YAML"
+  - "cpanm -n Test::Pod Test::Pod::Coverage Data::Validate::Domain Data::Validate::IP YAML::LibYAML"
   - "cpanm -n https://github.com/mojolicious/json-validator/archive/master.tar.gz"
   - "cpanm -n --installdeps ."
 notifications:

--- a/t/renderer.t
+++ b/t/renderer.t
@@ -44,7 +44,7 @@ sub custom_openapi_renderer {
 
   $data->{messages}  = delete $data->{errors} if $data->{errors};
   $data->{t}         = $^T                    if ref $data eq 'HASH';
-  $data->{exception} = $c->stash('exception') if $c->stash('exception');
+  $data->{exception} = $c->stash('exception')->message if $c->stash('exception');
 
   return Mojo::JSON::encode_json($data);
 }


### PR DESCRIPTION
Current test relies on the exception stringifying to `->message`. Which has changed with the deprecation of `->verbose`.

## References

* #132