### PR TITLE
Resolve failing test in openapi-client

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -69,6 +69,8 @@ sub _add_default_response {
   my ($self, $op_spec) = @_;
   my $name        = $self->{default_response_name};
   my $schema_data = $self->validator->schema->data;
+  # turn off with config { default_response_codes => [] }
+  return unless @{$self->{default_response_codes}};
 
   my $ref
     = $self->validator->version ge '3'


### PR DESCRIPTION
This PR resolves the failing test in openapi-client.

The code in the [openapi-client test](https://github.com/jhthorsen/openapi-client/blob/5b53b799a53712ecea77325aea144c19432550d4/t/command-local-with-ref.t#L15-L16) leads me to believe that the intent of an empty array for `default_response_codes` in the config is to not alter the definitions of the schema. In this case the function will return early.

**edit** with some [changes](https://github.com/kiwiroy/openapi-client/commit/02044d5b5c446eec5cbfa8dfbc27b98c1c5c0a37) to dependency installation the openapi-client status is now [![Build Status](https://travis-ci.com/kiwiroy/openapi-client.svg?branch=default-response-refs)](https://travis-ci.com/kiwiroy/openapi-client)