### PR TITLE
Use Trusty for perl <5.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: perl
-perl:
-  - "5.20"
-  - "5.16"
-  - "5.10"
+matrix:
+  include:
+    - perl: "5.28"
+      dist: xenial
+    - perl: "5.20"
+      dist: trusty
+    - perl: "5.16"
+      dist: trusty
+    - perl: "5.10"
+      dist: trusty
 env:
   - "HARNESS_OPTIONS=j6"
 install:


### PR DESCRIPTION
Add 5.28 and keep [![Build Status](https://travis-ci.com/kiwiroy/mojolicious-plugin-openapi.svg?branch=trusty-only)](https://travis-ci.com/kiwiroy/mojolicious-plugin-openapi) to reduce contributor friction.