### PR TITLE
turn off -st option, to allow for "perltidy -b $filename"

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -10,3 +10,4 @@
 -bt=2    # High brace tightness
 -sbt=2   # High square bracket tightness
 -isbc    # Don't indent comments without leading space
+-nst     # undo -st from -pbp, to allow for command line use


### PR DESCRIPTION
 ### Summary
Now it's possible for the user to run perltidy manually.

 ### Motivation
Because perltidy is mandatory for getting patches into this repository

