### PR TITLE
this object belongs under components->schemas

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -72,12 +72,12 @@ sub _add_default_response {
 
   my $ref
     = $self->validator->version ge '3'
-    ? ($schema_data->{components}{responses}{$name} ||= $self->_default_schema)
+    ? ($schema_data->{components}{schemas}{$name} ||= $self->_default_schema)
     : ($schema_data->{definitions}{$name} ||= $self->_default_schema);
 
   my %schema
     = $self->validator->version ge '3'
-    ? ('$ref' => "#/components/responses/$name")
+    ? ('$ref' => "#/components/schemas/$name")
     : ('$ref' => "#/definitions/$name");
 
   tie %schema, 'JSON::Validator::Ref', $ref, $schema{'$ref'}, $schema{'$ref'};

--- a/lib/Mojolicious/Plugin/OpenAPI/SpecRenderer.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/SpecRenderer.pm
@@ -85,9 +85,7 @@ sub _render_spec {
   local $spec->{basePath} = $c->url_for($spec->{basePath});
   local $spec->{host}     = $c->req->url->to_abs->host_port;
 
-  if ($self->validator->version ge '3') {
-    delete $spec->{$_} for qw/basePath host/;
-  }
+  delete @$spec{qw(basePath host)} if $self->validator->version ge '3';
 
   return $c->render(json => $spec) unless $format eq 'html';
   return $c->render(

--- a/lib/Mojolicious/Plugin/OpenAPI/SpecRenderer.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/SpecRenderer.pm
@@ -85,6 +85,10 @@ sub _render_spec {
   local $spec->{basePath} = $c->url_for($spec->{basePath});
   local $spec->{host}     = $c->req->url->to_abs->host_port;
 
+  if ($self->validator->version ge '3') {
+    delete $spec->{$_} for qw/basePath host/;
+  }
+
   return $c->render(json => $spec) unless $format eq 'html';
   return $c->render(
     handler   => 'ep',

--- a/t/register.t
+++ b/t/register.t
@@ -91,7 +91,7 @@ $t->options_ok('/oa3/users?method=get')->status_is(200)
   ->json_is('/responses/400/description', 'default Mojolicious::Plugin::OpenAPI response')
   ->json_is(
   '/responses/400/content/application~1json/schema/$ref',
-  '#/definitions/__components_responses_DefaultResponse'
+  '#/definitions/__components_schemas_DefaultResponse'
   );
 
 $t->options_ok('/one/user?method=post')->status_is(200)


### PR DESCRIPTION
 ### Summary
The type of object created for the default response, is created as a Schema object, not a response object.

Also clean out a few keys that does not belong in OpenAPI spec v3

 ### Motivation
Place the created default schema in the correct place as described in v3 specification, but also removal of few keys which does not belong there

### References

* https://swagger.io/specification/#schema
* https://swagger.io/specification/#schemaObject
* https://swagger.io/specification/#responsesObject