### PR TITLE
Fix failing test due to recent JSON::Validator release

### DIFF
--- a/t/register.t
+++ b/t/register.t
@@ -91,7 +91,7 @@ $t->options_ok('/oa3/users?method=get')->status_is(200)
   ->json_is('/responses/400/description', 'default Mojolicious::Plugin::OpenAPI response')
   ->json_is(
   '/responses/400/content/application~1json/schema/$ref',
-  '#/definitions/__components_schemas_DefaultResponse'
+  '#/definitions/_components_schemas_DefaultResponse'
   );
 
 $t->options_ok('/one/user?method=post')->status_is(200)


### PR DESCRIPTION
### Summary

This PR fixes a failing test due to changes in the recent JSON::Validator release

### Motivation

No more failing tests




