### PR TITLE
Override generate_definitions_path()

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 # You can install this project with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/mojolicious-plugin-openapi/archive/master.tar.gz
 requires "Mojolicious"     => "8.00";
-requires "JSON::Validator" => "3.15";
+requires "JSON::Validator" => "3.16";
 
 recommends "Text::Markdown" => "1.0.31";
 recommends "YAML::XS"       => "0.75";

--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -26,14 +26,20 @@ has generate_definitions_path => sub {
   return sub {
     my $ref = shift;
 
-    # Try to determine the path from the fqn
-    # We are only interested in the path in the fqn, so following fqn:
-    #
-    # #/components/schemas/some_schema, the returned path with be ['components', 'schemas']   (v3)
-    # #/definitions/some_schema, the returned path with be ['definitions']  (v2)
+    if ($self->version eq '3') {
 
-    my $path = Mojo::Path->new( $ref->fqn =~ m!^.*#/(.+)$! )->to_dir->parts;
-    return $path->[0] ? $path : ['definitions'];
+      # Try to determine the path from the fqn
+      # We are only interested in the path in the fqn, so following fqn:
+      #
+      # #/components/schemas/some_schema, the returned path with be ['components', 'schemas']
+      my $path = Mojo::Path->new($ref->fqn =~ m!^.*#/(components/.+)$!)->to_dir->parts;
+      return $path->[0] ? $path : ['definitions'];
+    }
+    else {
+
+      # By default return definitions as path
+      return ['definitions'];
+    }
   };
 };
 

--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -19,6 +19,28 @@ has version => 2;
 
 sub E { JSON::Validator::Error->new(@_) }
 
+has generate_definitions_path => sub {
+  my $self = shift;
+  Scalar::Util::weaken($self);
+
+  return sub {
+    my $ref = shift;
+    my @path;
+
+    # Try to determin the path from the fqn
+    if ($ref->fqn =~ m|^(.*)#/(.+)$|) {
+      my $relative = $1;
+      my $path     = $2;
+
+      @path = split '/', $path;
+      pop @path;
+    }
+
+    if   (@path) { \@path }
+    else         { [$self->{definitions_key} || 'definitions'] }
+  };
+};
+
 sub load_and_validate_schema {
   my ($self, $spec, $args) = @_;
 

--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -25,19 +25,15 @@ has generate_definitions_path => sub {
 
   return sub {
     my $ref = shift;
-    my @path;
 
-    # Try to determin the path from the fqn
-    if ($ref->fqn =~ m|^(.*)#/(.+)$|) {
-      my $relative = $1;
-      my $path     = $2;
+    # Try to determine the path from the fqn
+    # We are only interested in the path in the fqn, so following fqn:
+    #
+    # #/components/schemas/some_schema, the returned path with be ['components', 'schemas']   (v3)
+    # #/definitions/some_schema, the returned path with be ['definitions']  (v2)
 
-      @path = split '/', $path;
-      pop @path;
-    }
-
-    if   (@path) { \@path }
-    else         { [$self->{definitions_key} || 'definitions'] }
+    my $path = Mojo::Path->new( $ref->fqn =~ m!^.*#/(.+)$! )->to_dir->parts;
+    return $path->[0] ? $path : ['definitions'];
   };
 };
 
@@ -615,6 +611,10 @@ Validate the expanded version of the spec, (without any C<$ref>) against the
 OpenAPI schema.
 
 =back
+
+=head2 generate_definitions_path
+
+See L<JSON::Validator/generate_definitions_path>.
 
 =head2 validate_input
 

--- a/lib/Mojolicious/Plugin/OpenAPI/Guides/OpenAPI3.pod
+++ b/lib/Mojolicious/Plugin/OpenAPI/Guides/OpenAPI3.pod
@@ -354,16 +354,6 @@ L<https://github.com/mermade/openapi-webconverter>
 
 =head1 Known issues
 
-=head2 Path references
-
-Today L<JSON::Validator> does not handle references for OpenAPI v3
-
-  "$ref": '#/components/schemas/inputSchema'
-
-They will be places under '#/definitions/....', which will not pass validation.
-
-Work is currently underway to remedy this.
-
 =head2 File references
 
 Relative file references like the following

--- a/lib/Mojolicious/Plugin/OpenAPI/Guides/OpenAPI3.pod
+++ b/lib/Mojolicious/Plugin/OpenAPI/Guides/OpenAPI3.pod
@@ -214,6 +214,17 @@ the plugin
 
 =back
 
+=head3 References with files
+
+Only a file reference like
+
+  "$ref": "my-other-cool-component.json#/components/schemas/inputSchema"
+
+Is supported, though a valid path must be used for both the reference and in the
+referenced file, in order to produce a valid spec output.
+
+See L<Known Issues/File references> for unsupported file references
+
 =head2 Application
 
   package Myapp;
@@ -363,13 +374,6 @@ Relative file references like the following
 
 Will also be placed under '#/definitions/...', again producing a spec output
 which will not pass validation
-
-A reference like
-
-  "$ref": "my-other-cool-component.json#/components/schemas/inputSchema"
-
-Is not supported either, even though it would be easier to place it correctly
-in the final rendering of the spec
 
 =head1 SEE ALSO
 

--- a/t/register.t
+++ b/t/register.t
@@ -91,7 +91,7 @@ $t->options_ok('/oa3/users?method=get')->status_is(200)
   ->json_is('/responses/400/description', 'default Mojolicious::Plugin::OpenAPI response')
   ->json_is(
   '/responses/400/content/application~1json/schema/$ref',
-  '#/definitions/_components_schemas_DefaultResponse'
+  '#/components/schemas/DefaultResponse'
   );
 
 $t->options_ok('/one/user?method=post')->status_is(200)

--- a/t/register.t
+++ b/t/register.t
@@ -59,7 +59,8 @@ plugin OpenAPI => {
         description => 'Optional server description, e.g. Internal staging server for testing'
       }
     ],
-    paths => {
+    components => {schemas => {jobs => {type => 'array', items => {type => 'string'}}}},
+    paths      => {
       '/users' => {
         get => {
           summary     => 'Returns a list of users.',
@@ -69,6 +70,18 @@ plugin OpenAPI => {
               description => 'A JSON array of user names',
               content =>
                 {'application/json' => {schema => {type => 'array', items => {type => 'string'}}}}
+            }
+          }
+        }
+      },
+      '/jobs' => {
+        get => {
+          summary     => 'Returns a list of jobs.',
+          description => 'Optional extended description in CommonMark or HTML.',
+          responses   => {
+            '200' => {
+              description => 'A JSON array of job types',
+              content => {'application/json' => {schema => {'$ref' => '#/components/schemas/jobs'}}}
             }
           }
         }
@@ -89,10 +102,13 @@ $t->get_ok('/one')->status_is(200)
 $t->options_ok('/oa3/users?method=get')->status_is(200)
   ->json_is('/responses/200/description', 'A JSON array of user names')
   ->json_is('/responses/400/description', 'default Mojolicious::Plugin::OpenAPI response')
-  ->json_is(
-  '/responses/400/content/application~1json/schema/$ref',
-  '#/components/schemas/DefaultResponse'
-  );
+  ->json_is('/responses/400/content/application~1json/schema/$ref',
+  '#/components/schemas/DefaultResponse');
+
+$t->options_ok('/oa3/jobs?method=get')->status_is(200)
+  ->json_is('/responses/200/description', 'A JSON array of job types')
+  ->json_is('/responses/400/description', 'default Mojolicious::Plugin::OpenAPI response')
+  ->json_is('/responses/200/content/application~1json/schema/$ref', '#/components/schemas/jobs');
 
 $t->options_ok('/one/user?method=post')->status_is(200)
   ->json_is('/responses/200/description', 'ok')

--- a/t/spec/v3-invalid_file_refs.yaml
+++ b/t/spec/v3-invalid_file_refs.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  title: Test file refs
+  version: "1"
+servers:
+  - url: /api
+paths:
+  /test:
+    get:
+      operationId: File
+      parameters:
+        - $ref: "v3-invalid_include.yaml#/PCVersion"
+      responses:
+        "200":
+          description: thing
+          content:
+            "*/*":
+              schema:
+                type: string

--- a/t/spec/v3-invalid_file_refs_no_path.yaml
+++ b/t/spec/v3-invalid_file_refs_no_path.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  title: Test file refs
+  version: "1"
+servers:
+  - url: /api
+paths:
+  /test:
+    get:
+      operationId: File
+      parameters:
+        - $ref: "v3-valid_include.yaml#"
+      responses:
+        "200":
+          description: thing
+          content:
+            "*/*":
+              schema:
+                type: string

--- a/t/spec/v3-invalid_include.yaml
+++ b/t/spec/v3-invalid_include.yaml
@@ -1,0 +1,10 @@
+PCVersion:
+  name: pcversion
+  in: query
+  description: version of commands which will run on backend
+  schema:
+    type: string
+    enum:
+      - 9.6.1
+      - 10.1.0
+    default: 10.1.0

--- a/t/spec/v3-valid_file_refs.yaml
+++ b/t/spec/v3-valid_file_refs.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  title: Test file refs
+  version: "1"
+servers:
+  - url: /api
+paths:
+  /test:
+    get:
+      operationId: File
+      parameters:
+        - $ref: "v3-valid_include.yaml#/components/parameters/PCVersion"
+      responses:
+        "200":
+          description: thing
+          content:
+            "*/*":
+              schema:
+                type: string

--- a/t/spec/v3-valid_include.yaml
+++ b/t/spec/v3-valid_include.yaml
@@ -1,0 +1,12 @@
+components:
+  parameters:
+    PCVersion:
+      name: pcversion
+      in: query
+      description: version of commands which will run on backend
+      schema:
+        type: string
+        enum:
+          - 9.6.1
+          - 10.1.0
+        default: 10.1.0

--- a/t/v3-invalid_file_refs.t
+++ b/t/v3-invalid_file_refs.t
@@ -1,0 +1,26 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+use Mojolicious::Lite;
+use JSON::Validator::OpenAPI::Mojolicious;
+
+get '/test' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(status => 200, openapi => $c->param('pcversion'));
+  },
+  'File';
+
+plugin OpenAPI => {schema => 'v3', url => app->home->rel_file("spec/v3-invalid_file_refs.yaml")};
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/api')->status_is(200)->json_hasnt('/PCVersion/name')->json_has('/definitions')
+  ->content_like(qr/v3-invalid_include_yaml-PCVersion-/);
+
+my $json      = $t->get_ok('/api')->tx->res->body;
+my $validator = JSON::Validator::OpenAPI::Mojolicious->new(version => 3);
+eval { $validator->load_and_validate_schema($json, {schema => 'v3'}) };
+like $@, qr/Properties not allowed: definitions/,
+  'load_and_validate_schema fails, wrong placement of data';
+
+done_testing;

--- a/t/v3-invalid_file_refs_no_path.t
+++ b/t/v3-invalid_file_refs_no_path.t
@@ -1,0 +1,26 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+use Mojolicious::Lite;
+use JSON::Validator::OpenAPI::Mojolicious;
+
+get '/test' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(status => 200, openapi => $c->param('pcversion'));
+  },
+  'File';
+
+plugin OpenAPI => {schema => 'v3', url => app->home->rel_file("spec/v3-invalid_file_refs_no_path.yaml")};
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/api')->status_is(200)->json_hasnt('/PCVersion/name')->json_has('/definitions')
+  ->content_like(qr!\\/definitions\\/v3-valid_include_yaml-!);
+
+my $json      = $t->get_ok('/api')->tx->res->body;
+my $validator = JSON::Validator::OpenAPI::Mojolicious->new(version => 3);
+eval { $validator->load_and_validate_schema($json, {schema => 'v3'}) };
+like $@, qr/Properties not allowed: definitions/,
+  'load_and_validate_schema fails, wrong placement of data';
+
+done_testing;

--- a/t/v3-valid_file_refs.t
+++ b/t/v3-valid_file_refs.t
@@ -16,7 +16,6 @@ my $t = Test::Mojo->new;
 
 $t->get_ok('/api')->status_is(200)->json_is('/components/parameters/PCVersion/name', 'pcversion');
 
-use DDP; say np $t->get_ok('/api')->tx->res->json;
 my $json      = $t->get_ok('/api')->tx->res->body;
 my $validator = JSON::Validator::OpenAPI::Mojolicious->new(version => 3);
 is $validator->load_and_validate_schema($json, {schema => 'v3'}), $validator,

--- a/t/v3-valid_file_refs.t
+++ b/t/v3-valid_file_refs.t
@@ -1,0 +1,25 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+use Mojolicious::Lite;
+use JSON::Validator::OpenAPI::Mojolicious;
+
+get '/test' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(status => 200, openapi => $c->param('pcversion'));
+  },
+  'File';
+
+plugin OpenAPI => {schema => 'v3', url => app->home->rel_file("spec/v3-valid_file_refs.yaml")};
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/api')->status_is(200)->json_is('/components/parameters/PCVersion/name', 'pcversion');
+
+use DDP; say np $t->get_ok('/api')->tx->res->json;
+my $json      = $t->get_ok('/api')->tx->res->body;
+my $validator = JSON::Validator::OpenAPI::Mojolicious->new(version => 3);
+is $validator->load_and_validate_schema($json, {schema => 'v3'}), $validator,
+  'load_and_validate_schema; prove we get a valid spec';
+
+done_testing;


### PR DESCRIPTION
 in order to render proper OpenAPIv3 spec, overriding of generate_definitions_path() is needed

Latest changes to JSON::Validator makes it possible to render proper OpenAPIv3 specs for references

Reference to #138 