### PR TITLE
Return req body instead of json

### DIFF
--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -273,7 +273,7 @@ sub _get_request_data {
     return $self->{cache}{$in} ||= {map { lc($_) => $headers->{$_} } keys %$headers};
   }
   elsif ($in eq 'body') {
-    return $c->req->json;
+    return $c->req->body;
   }
   else {
     _confess_invalid_in($in);


### PR DESCRIPTION
In OpenAPI 3.0, you can specify any content type for the request body, not just JSON.

https://swagger.io/docs/specification/describing-request-body/

> The requestBody is more flexible in that it lets you consume different media types, such as JSON, XML, form data, plain text, and others, and use different schemas for different media types.