### PR TITLE
Handle default for requestBody properties

### DIFF
--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -390,7 +390,7 @@ sub _validate_request_body {
         if (exists $content_props->{$prop}{default} and !exists $body->{$prop}) {
           $body->{$prop} = $content_props->{$prop}{default};
         }
-        $self->_coerce_input($content_props->{$prop}, $body->{$prop});
+        $self->_coerce_input($content_props->{$prop}{type}, $body->{$prop});
       }
     }
     return $self->_validate_request_value($content, body => $body);


### PR DESCRIPTION
In OAS3, requestBody properties can have a `default` like this:

```
requestBody:
  required: true
  content:
    application/json:
      schema:
        type: object
        properties:
          foo:
            type: string
            default: bar
```

Where if `foo` is not given in the request body, the value `bar` must
be used instead.

Fixes #176