### PR TITLE
Add "Access-Control-Allow-Credentials" header support

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI/Cors.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Cors.pm
@@ -337,6 +337,17 @@ L</openapi_cors_default_exchange_callback> is used. Examples:
   $app->defaults(openapi_cors_allowed_origins => [qr{^https?://whatever.example.com}]);
   $c->stash(openapi_cors_allowed_origins => [qr{^https?://whatever.example.com}]);
 
+=head2 openapi_cors_allow_credentials
+
+This variable addes the "Access-Control-Allow-Credentials" header to responses
+allowing expose response to frontend javascript code when credentials are
+used(cookies, authorization headers or TLS certificates)
+
+Here's an example
+
+  $app->defaults(openapi_cors_allow_credentials => 1);
+  $c->stash(openapi_cors_allow_credentials => 1);
+
 =head2 openapi_cors_default_exchange_callback
 
 This value holds a default callback that will be used by

--- a/lib/Mojolicious/Plugin/OpenAPI/Cors.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Cors.pm
@@ -141,6 +141,10 @@ sub _set_default_headers {
     $res_h->access_control_allow_origin($req_h->origin);
   }
 
+  unless ($res_h->header('Access-Control-Allow-Credentials') || !$c->stash('openapi_cors_allow_credentials')) {
+    $res_h->header('Access-Control-Allow-Credentials' => 'true');
+  }
+
   return unless $c->stash('openapi_cors_type') eq 'preflighted';
 
   unless ($res_h->header('Access-Control-Allow-Headers')) {


### PR DESCRIPTION
Hello,

working on a company project, we have a frontend that makes CORS requests and uses cookie-based authentication.

Our cors requests were failing because the header `Access-Control-Allow-Credentials` was missing, so we have added it on our implementation.

It would be nice the plugin supports this kind of requests, so here's a pr that adds this feature, of course, it's off by default to avoid any issues for projects using it.

Hope this helps!
