### PR TITLE
Another take on allowing different status codes

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI/Security.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Security.pm
@@ -27,7 +27,8 @@ sub _build_action {
     my ($sync_mode, $n_checks, %res) = (1, 0);
 
     my $security_completed = sub {
-      my ($i, $status, @errors) = (0, 401);
+      my ($i, @errors) = (0);
+      $c->stash( status => 401 ) unless $c->stash( 'status' );
 
     SECURITY_AND:
       for my $security_and (@security_or) {
@@ -47,7 +48,7 @@ sub _build_action {
           chomp $@;
           $c->app->log->error($@);
           @errors = ({message => 'Internal Server Error.', path => '/'});
-          $status = 500;
+          $c->stash( status => 500 );
           last SECURITY_AND;
         }
 
@@ -56,7 +57,7 @@ sub _build_action {
         $i++;
       }
 
-      $c->render(openapi => {errors => \@errors}, status => $status);
+      $c->render(openapi => {errors => \@errors} );
       $n_checks = -1;    # Make sure we don't render twice
     };
 

--- a/lib/Mojolicious/Plugin/OpenAPI/Security.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Security.pm
@@ -28,7 +28,7 @@ sub _build_action {
 
     my $security_completed = sub {
       my ($i, @errors) = (0);
-      $c->stash( status => 401 ) unless $c->stash( 'status' );
+      $c->stash(status => 401) unless $c->stash('status');
 
     SECURITY_AND:
       for my $security_and (@security_or) {
@@ -48,7 +48,7 @@ sub _build_action {
           chomp $@;
           $c->app->log->error($@);
           @errors = ({message => 'Internal Server Error.', path => '/'});
-          $c->stash( status => 500 );
+          $c->stash(status => 500);
           last SECURITY_AND;
         }
 
@@ -57,7 +57,7 @@ sub _build_action {
         $i++;
       }
 
-      $c->render(openapi => {errors => \@errors} );
+      $c->render(openapi => {errors => \@errors});
       $n_checks = -1;    # Make sure we don't render twice
     };
 

--- a/t/plugin-security-extended-status.t
+++ b/t/plugin-security-extended-status.t
@@ -10,7 +10,6 @@ get '/securitytest' => sub {
   },
   'securitytest';
 
-our %checks;
 plugin OpenAPI => {
   url      => 'data://main/sec.yaml',
   schema   => 'v3',
@@ -34,29 +33,13 @@ plugin OpenAPI => {
 
 my $t = Test::Mojo->new;
 
-{
-  local %checks;
+$t->get_ok('/api/securitytest' => {apikey => 'authorized', apiuser => 'authorized'})->status_is(200);
 
-  $t->get_ok('/api/securitytest' => {apikey => 'authorized', apiuser => 'authorized'})
-    ->status_is(200);
+$t->get_ok('/api/securitytest' => {apikey => 'authenticated', apiuser => 'authenticated'})->status_is(403);
 
-}
+$t->get_ok('/api/securitytest' => {apikey => 'unknown', apiuser => 'unknown'})->status_is(401);
 
-{
-  local %checks;
-  $t->get_ok('/api/securitytest' => {apikey => 'authenticated', apiuser => 'authenticated'})
-    ->status_is(403);
-}
-
-{
-  local %checks;
-  $t->get_ok('/api/securitytest' => {apikey => 'unknown', apiuser => 'unknown'})->status_is(401);
-}
-
-{
-  local %checks;
-  $t->get_ok('/api/securitytest')->status_is(401);
-}
+$t->get_ok('/api/securitytest')->status_is(401);
 
 
 done_testing;
@@ -83,8 +66,6 @@ paths:
       responses:
         200:
           $ref: "#/components/responses/200_OK_message"
-        401:
-          $ref: "#/components/responses/401_Unauthorized"
         403:
           $ref: "#/components/responses/403_Forbidden"
 components:
@@ -130,12 +111,6 @@ components:
                 type: string
               path:
                 type: string
-    401_Unauthorized:
-      description: Missing authorization
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
     403_Forbidden:
       description: Insufficient priviliges
       content:

--- a/t/plugin-security-extended-status.t
+++ b/t/plugin-security-extended-status.t
@@ -1,0 +1,150 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+
+use Mojolicious::Lite;
+
+get '/securitytest' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->render(openapi => {message => "ok"}, status => 200);
+  },
+  'securitytest';
+
+our %checks;
+plugin OpenAPI => {
+  url      => 'data://main/sec.yaml',
+  schema   => 'v3',
+  security => {
+    api_key => sub {
+      my ($self, $definition, $scopes, $cb) = @_;
+      my $apikey  = $self->req->headers->header('apikey');
+      my $apiuser = $self->req->headers->header('apiuser');
+      return $self->$cb("apikey/apiuser missing") unless $apikey and $apiuser;
+      if ($apikey eq "authenticated" and $apiuser eq "authenticated") {
+        $self->stash(status => 403);
+        return $self->$cb("Permission denied");
+      }
+      if ($apikey eq "authorized" and $apiuser eq "authorized") {
+        return $self->$cb();
+      }
+      return $self->$cb("Unauthorized");
+    },
+  },
+};
+
+my $t = Test::Mojo->new;
+
+{
+  local %checks;
+
+  $t->get_ok('/api/securitytest' => {apikey => 'authorized', apiuser => 'authorized'})
+    ->status_is(200);
+
+}
+
+{
+  local %checks;
+  $t->get_ok('/api/securitytest' => {apikey => 'authenticated', apiuser => 'authenticated'})
+    ->status_is(403);
+}
+
+{
+  local %checks;
+  $t->get_ok('/api/securitytest' => {apikey => 'unknown', apiuser => 'unknown'})->status_is(401);
+}
+
+{
+  local %checks;
+  $t->get_ok('/api/securitytest')->status_is(401);
+}
+
+
+done_testing;
+
+__DATA__
+@@ sec.yaml
+openapi: 3.0.2
+info:
+  title: CSApi
+  version: "1.0"
+  description: API test
+servers:
+- url: /api
+security:
+  - api_key: []
+    api_user: []
+paths:
+  /securitytest:
+    get:
+      x-mojo-name: securitytest
+      summary: test security
+      description: >
+        Will grant authenticated and authorized apikeys access
+      responses:
+        200:
+          $ref: "#/components/responses/200_OK_message"
+        401:
+          $ref: "#/components/responses/401_Unauthorized"
+        403:
+          $ref: "#/components/responses/403_Forbidden"
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      description: API key to authorize requests.
+      name: apikey
+      in: header
+    api_user:
+      type: apiKey
+      description: Username going with that key.
+      name: apiuser
+      in: header
+  schemas:
+    Error:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+              path:
+                type: string
+  responses:
+    200_OK_message:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - message
+            properties:
+              message:
+                type: string
+              path:
+                type: string
+    401_Unauthorized:
+      description: Missing authorization
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    403_Forbidden:
+      description: Insufficient priviliges
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    DefaultResponse:
+      description: Default Response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"


### PR DESCRIPTION
This one stashes a default 401 - unless there already is a status in the stash
A 500 will always be stashed.

With this approach the security callback can stash its own value (like 403) when user is authenticated but not authorized

In my case I do it like this:

```
if ($assume_client ne $apiuser and $account->{level} < 9999) {
    $c->stash( status => 403 );
    return 'permission denied' ;
};
```

Advantage over my other approach:

* fewer changes in the original module
* no new requirement for the parameter to $c->$cb