### PR TITLE
support optional requestBody

### DIFF
--- a/lib/JSON/Validator/OpenAPI/Mojolicious.pm
+++ b/lib/JSON/Validator/OpenAPI/Mojolicious.pm
@@ -510,7 +510,8 @@ sub _validate_request_body {
   }
 
   return JSON::Validator::E('/' => "No requestBody rules defined for Content-Type $ct.") if $ct;
-  return JSON::Validator::E('/', 'Invalid Content-Type.');
+  return JSON::Validator::E('/', 'Invalid Content-Type.') if $body_schema->{required};
+  return;
 }
 
 sub _validate_request_value {


### PR DESCRIPTION
According to the OpenAPI specification, requestBody can be optional so we need to follow that.

ref: https://github.com/jhthorsen/mojolicious-plugin-openapi/issues/170#issuecomment-671791298