### PR TITLE
Compatible with J::V 5.00

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           cpanm -n Test::Pod Test::Pod::Coverage Data::Validate::Domain Data::Validate::IP YAML::LibYAML
-          cpanm -n https://github.com/mojolicious/json-validator/archive/master.tar.gz
+          cpanm -n https://github.com/mojolicious/json-validator/archive/v5_oh.tar.gz
           cpanm -n --installdeps .
       - name: Run tests
         run: prove -l t/*.t

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for perl distribution Mojolicious-Plugin-OpenAPI
 
 5.00 Not Released
+ - Fix "version_from_class" uses the VERSION from $app by default
  - Compatible with JSON::Validator 5.00
  - Removed support for "allow_invalid_ref"
  - Changed render_spec() to require a JSON::Validator::Schema::OpenAPIv2 object

--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for perl distribution Mojolicious-Plugin-OpenAPI
 
+5.00 Not Released
+ - Compatible with JSON::Validator 5.00
+ - Removed support for "allow_invalid_ref"
+ - Changed render_spec() to require a JSON::Validator::Schema::OpenAPIv2 object
+
 4.06 2021-09-14T14:08:26+0200
  - Add support for adding $route->to(...) programmatically
  - Fix link to Convos example spec #222

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 # You can install this project with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/mojolicious-plugin-openapi/archive/master.tar.gz
 requires "Mojolicious"     => "9.00";
-requires "JSON::Validator" => "4.18";
+requires "JSON::Validator" => "4.99";
 
 recommends "Text::Markdown" => "1.0.31";
 

--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -8,7 +8,7 @@ use Mojolicious::Plugin::OpenAPI::Parameters;
 
 use constant DEBUG => $ENV{MOJO_OPENAPI_DEBUG} || 0;
 
-our $VERSION = '4.06';
+our $VERSION = '4.99_01';
 
 has route     => sub {undef};
 has validator => sub { JSON::Validator::Schema->new; };

--- a/lib/Mojolicious/Plugin/OpenAPI.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI.pm
@@ -18,7 +18,6 @@ sub register {
 
   $self->validator(JSON::Validator->new->schema($config->{url} || $config->{spec})->schema);
   $self->validator->coerce($config->{coerce})               if defined $config->{coerce};
-  $self->validator->allow_invalid_ref(1)                    if $config->{allow_invalid_ref};
   $self->_set_schema_version($config->{version_from_class}) if $config->{version_from_class};
 
   my $errors = $config->{skip_validating_specification} ? [] : $self->validator->errors;
@@ -296,7 +295,7 @@ sub _self {
 
 sub _set_schema_version {
   my ($self, $class) = @_;
-  $self->validator->data->{info}{version} = $class->VERSION;
+  $self->validator->data->{info}{version} = sprintf '%s', $class->VERSION;
 }
 
 1;
@@ -483,13 +482,6 @@ documents. The return value is the object instance, which allow you to access
 the L</ATTRIBUTES> after you load the plugin.
 
 C<%config> can have:
-
-=head3 allow_invalid_ref
-
-The OpenAPI specification does not allow "$ref" at every level, but setting
-this flag to a true value will ignore the $ref check.
-
-Note that setting this attribute is discourage.
 
 =head3 coerce
 

--- a/lib/Mojolicious/Plugin/OpenAPI/Parameters.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Parameters.pm
@@ -1,7 +1,7 @@
 package Mojolicious::Plugin::OpenAPI::Parameters;
 use Mojo::Base 'Mojolicious::Plugin';
 
-use JSON::Validator::Util qw(is_type);
+use JSON::Validator::Util qw(is_bool);
 use Mojo::JSON qw(encode_json);
 
 sub register {
@@ -17,7 +17,7 @@ sub register {
 }
 
 sub _bool {
-  return map { !is_type($_, 'BOOL') ? $_ : $_ ? 'true' : 'false' } @_;
+  return map { !is_bool($_) ? $_ : $_ ? 'true' : 'false' } @_;
 }
 
 sub _helper_build_response_body {

--- a/t/jv-recursion.t
+++ b/t/jv-recursion.t
@@ -3,15 +3,23 @@ use Test::Mojo;
 use Test::More;
 use JSON::Validator::Schema::OpenAPIv2;
 
-my $data = {};
-$data->{rec} = $data;
+TODO: {
+  todo_skip
+    'At this moment in spacetime, I do not know how to suppport both a recursive schema and a recusrive data structure',
+    2;
 
-$SIG{ALRM} = sub { die 'Recursion!' };
-alarm 2;
-my @errors
-  = JSON::Validator::Schema::Draft4->new('data://main/spec.json')->validate({top => $data});
-is $@, '', 'no error';
-is_deeply(\@errors, [], 'avoided recursion');
+  my ($data, @errors) = ({});
+  $data->{rec} = $data;
+
+  eval {
+    local $SIG{ALRM} = sub { die 'Recursion!' };
+    alarm 2;
+    @errors
+      = JSON::Validator::Schema::Draft4->new('data://main/spec.json')->validate({top => $data});
+  };
+  is $@, '', 'no error';
+  is_deeply(\@errors, [], 'avoided recursion');
+}
 
 note 'This part of the test checks that we don\'t go into an infite loop';
 eval {

--- a/t/plugin-security-v3.t
+++ b/t/plugin-security-v3.t
@@ -108,54 +108,56 @@ my %security_definition
 
 my $t = Test::Mojo->new;
 
-{
+subtest 'post global' => sub {
   local %checks;
   $t->post_ok('/api/global' => json => {})->status_is(200)->json_is('/ok' => 1);
   is_deeply \%checks, {pass1 => 1}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'options global' => sub {
+
   # global does not define an options handler, so it gets the default
   # which is allowed through the security
   local %checks;
   $t->options_ok('/api/global')->status_is(200);
   is_deeply \%checks, {}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'post simple' => sub {
   local %checks;
   $t->post_ok('/api/simple' => json => {})->status_is(200)->json_is('/ok' => 1);
   is_deeply \%checks, {pass2 => 1}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'options options' => sub {
+
   # route defined with an options handler so it must use the defined security
   local %checks;
   $t->options_ok('/api/options' => json => {})->status_is(200)->json_is('/ok' => 1);
   is_deeply \%checks, {pass1 => 1}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'post fail_or_pass' => sub {
   local %checks;
   $t->post_ok('/api/fail_or_pass' => json => {})->status_is(200)->json_is('/ok' => 1);
   is_deeply \%checks, {fail1 => 1, pass1 => 1}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'post fail_or_pass - env' => sub {
   local $ENV{DUMMY_DB_ERROR} = 1;
   $t->post_ok('/api/fail_or_pass' => json => {})->status_is(500)
     ->json_is('/errors/0/message', 'Internal Server Error.')->json_is('/errors/0/path', '/');
-}
+};
 
-{
+subtest 'post fail_and_pass' => sub {
   local %checks;
   $t->post_ok('/api/fail_and_pass' => json => {})->status_is(401)
     ->json_is(
     {errors => [{message => 'Failed fail1', path => '/security/0/fail1'}], status => 401});
   is_deeply \%checks, {fail1 => 1, pass1 => 1}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'post multiple_fail' => sub {
   local %checks;
   $t->post_ok('/api/multiple_fail' => json => {})->status_is(401)->json_is({
     status => 401,
@@ -165,9 +167,9 @@ my $t = Test::Mojo->new;
     ]
   });
   is_deeply \%checks, {fail1 => 1, fail2 => 1}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'post multiple_and_fail' => sub {
   local %checks;
   $t->post_ok('/api/multiple_and_fail' => json => {})->status_is(401)->json_is({
     status => 401,
@@ -177,30 +179,28 @@ my $t = Test::Mojo->new;
     ]
   });
   is_deeply \%checks, {fail1 => 1, fail2 => 1}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'post fail_escape' => sub {
   local %checks;
-  $t->post_ok('/api/fail_escape' => json => {})->status_is(401)->json_is(
-    {
-      errors => [{message => 'Failed ~fail/escape', path => '/security/0/~0fail~1escape'}],
-      status => 401
-    }
-  );
+  $t->post_ok('/api/fail_escape' => json => {})->status_is(401)->json_is({
+    errors => [{message => 'Failed ~fail/escape', path => '/security/0/~0fail~1escape'}],
+    status => 401
+  });
   is_deeply \%checks, {'~fail/escape' => 1}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'post cache' => sub {
   local %checks;
   $t->post_ok('/api/cache' => json => {})->status_is(200)->json_is('/ok' => 1);
   is_deeply \%checks, {fail1 => 1, pass1 => 1, pass2 => 1}, 'expected checks occurred';
-}
+};
 
-{
+subtest 'post die' => sub {
   local %checks;
   $t->post_ok('/api/die' => json => {})->status_is(500)->json_has('/errors/0/message');
   is_deeply \%checks, {die => 1}, 'expected checks occurred';
-}
+};
 
 done_testing;
 

--- a/t/plugin-spec-renderer-standalone.t
+++ b/t/plugin-spec-renderer-standalone.t
@@ -13,7 +13,7 @@ my $app      = Mojolicious->new;
 $app->plugin('Mojolicious::Plugin::OpenAPI::SpecRenderer' =>
     {url => $petstore->to_string, spec_route_name => 'my.cool.api', version_from_class => 'main'});
 
-my $custom_spec = JSON::Validator->new->schema($petstore->to_string)->bundle;
+my $custom_spec = JSON::Validator->new->schema($petstore->to_string)->schema->bundle;
 $app->routes->get('/my-unknown-doc' => sub { shift->openapi->render_spec });
 $app->routes->get(
   '/my-cool-doc' => [format => [qw(html json)]],

--- a/t/v2-validate-schema.t
+++ b/t/v2-validate-schema.t
@@ -8,9 +8,6 @@ like $@, qr{/info: Missing property}si, 'missing spec elements';
 eval { plugin OpenAPI => {url => 'data://main/swagger2/issues/89.json'} };
 like $@, qr{/definitions/\$ref}si, 'ref in the wrong place';
 
-eval { plugin OpenAPI => {allow_invalid_ref => 1, url => 'data://main/swagger2/issues/89.json'} };
-ok !$@, 'allow_invalid_ref=1' or diag $@;
-
 eval { plugin OpenAPI => {skip_validating_specification => 1, url => 'data://main/invalid.json'} };
 ok !$@, 'skip_validating_specification=1' or diag $@;
 

--- a/t/v3-bundle.t
+++ b/t/v3-bundle.t
@@ -1,0 +1,144 @@
+use Mojo::Base -strict;
+use Mojo::File 'path';
+use Test::Mojo;
+use Test::More;
+
+use Mojolicious::Lite;
+
+get '/pets' => sub {
+  my $c = shift->openapi->valid_input or return;
+  $c->res->headers->header('x-next' => $c->param('limit') // 0);
+  $c->render(openapi => $c->param('limit') ? [] : {});
+  },
+  'listPets';
+
+plugin OpenAPI => {url => 'data:///spec.json'};
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/v1.json')->status_is(200)->json_is('/openapi' => '3.0.0')
+  ->json_is('/info/title' => 'Swagger Petstore')->json_like('/servers/0/url' => qr{^http://.*/v1$})
+  ->json_is('/security/0/pass1', [])->json_is('/components/securitySchemes/apiKey/type' => 'http')
+  ->json_is('/components/schemas/DefaultResponse/properties/errors/items/properties/message/type',
+  'string')->json_is('/components/schemas/Pet/required/0', 'id')
+  ->json_is('/components/schemas/Pets/type',                       'array')
+  ->json_is('/paths/~1pets~1{petId}/get/parameters/0/schema/type', 'string')
+  ->json_is('/paths/~1pets~1{petId}/get/responses/500/content/application~1json/schema/$ref',
+  '#/components/schemas/DefaultResponse')
+  ->json_hasnt('/paths/~1pets~1{petId}/get/parameters/0/type')->json_hasnt('/basePath');
+
+done_testing;
+
+__DATA__
+@@ spec.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "license": {
+      "name": "MIT"
+    },
+    "title": "Swagger Petstore",
+    "version": "1.0.0"
+  },
+  "servers": [
+    { "url": "http://petstore.swagger.io/v1" }
+  ],
+  "security": [{"pass1": []}],
+  "paths": {
+    "/pets/{petId}": {
+      "get": {
+        "operationId": "showPetById",
+        "tags": [ "pets" ],
+        "summary": "Info for a specific pet",
+        "parameters": [
+          {
+            "description": "The id of the pet to retrieve",
+            "in": "path",
+            "name": "petId",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "description": "Indicates if the age is wanted in the response object",
+            "in": "query",
+            "name": "wantAge",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              },
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets": {
+      "get": {
+        "operationId": "listPets",
+        "summary": "List all pets",
+        "tags": [ "pets" ],
+        "parameters": [
+          {
+            "description": "How many items to return at one time (max 100)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "schema": { "type": "string" },
+                "description": "A link to the next page of responses"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pets" }
+              },
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/Pets" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    },
+    "schemas": {
+      "Pets": {
+        "type": "array",
+        "items": { "$ref": "#/components/schemas/Pet" }
+      },
+      "Pet": {
+        "required": [ "id", "name" ],
+        "properties": {
+          "tag": { "type": "string" },
+          "id": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" },
+          "age": { "type": "integer" }
+        }
+      }
+    }
+  }
+}

--- a/t/v3-invalid_file_refs_no_path.t
+++ b/t/v3-invalid_file_refs_no_path.t
@@ -13,11 +13,11 @@ plugin OpenAPI => {url => app->home->rel_file('spec/v3-invalid_file_refs_no_path
 
 my $t = Test::Mojo->new;
 
-$t->get_ok('/api')->status_is(200)->json_hasnt('/PCVersion/name')->json_has('/definitions')
-  ->content_like(qr!\\/definitions\\/v3-valid_include_yaml-!);
+$t->get_ok('/api')->status_is(200)->json_hasnt('/PCVersion/name')->json_has('/components/schemas')
+  ->content_like(qr!v3-valid_include_yaml!);
 
-eval { die JSON::Validator::Schema::OpenAPIv3->new($t->get_ok('/api')->tx->res->body)->errors->[0] };
-like $@, qr/Properties not allowed: definitions/,
+eval { die JSON::Validator::Schema::OpenAPIv3->new($t->get_ok('/api')->tx->res->json)->errors->[0] };
+like $@, qr/Properties not allowed: components/,
   'load_and_validate_schema fails, wrong placement of data';
 
 done_testing;

--- a/t/v3-valid_file_refs.t
+++ b/t/v3-valid_file_refs.t
@@ -12,10 +12,9 @@ get '/test' => sub {
 plugin OpenAPI => {url => app->home->rel_file('spec/v3-valid_file_refs.yaml')};
 
 my $t = Test::Mojo->new;
-
 $t->get_ok('/api')->status_is(200)->json_is('/components/parameters/PCVersion/name', 'pcversion');
 
 my $validator = JSON::Validator::Schema::OpenAPIv3->new($t->get_ok('/api')->tx->res->body);
-is $validator->errors->[0], undef, 'load_and_validate_schema; prove we get a valid spec';
+is $validator->errors->[0], undef, 'valid bundled spec';
 
 done_testing;


### PR DESCRIPTION
Updated the codebase to be in sync with https://github.com/jhthorsen/json-validator/pull/251

Can be tested with:

```
cpanm https://github.com/jhthorsen/json-validator/archive/v5_oh.tar.gz
cpanm https://github.com/jhthorsen/mojolicious-plugin-openapi/archive/v5_oh.tar.gz
```

Note that the version number will be wrong, but it will have the new code.