### PR TITLE
Update Security.pm to fix #254

### DIFF
--- a/lib/Mojolicious/Plugin/OpenAPI/Security.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Security.pm
@@ -67,6 +67,7 @@ sub _build_action {
 
         if (!$security_cb) {
           $res{$name} = {message => "No security callback for $name."} unless exists $res{$name};
+          $security_completed->(); # missing handler is always an error
         }
         elsif (!exists $res{$name}) {
           $res{$name} = undef;


### PR DESCRIPTION
The security plugin does not check for missing handlers correctly. The error handling code is never reached if there is only one handler in the spec and it is missing in the code.

This patch adds the necessary code path.