### PR TITLE
Include file uploads in validation

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,7 @@ my %WriteMakefileArgs = (
   ABSTRACT_FROM => 'lib/Mojolicious/Plugin/OpenAPI.pm',
   VERSION_FROM  => 'lib/Mojolicious/Plugin/OpenAPI.pm',
   TEST_REQUIRES => {'Test::More'      => '0.88'},
-  PREREQ_PM     => {'JSON::Validator' => '5.13', 'Mojolicious' => '9.00'},
+  PREREQ_PM     => {'JSON::Validator' => '5.17', 'Mojolicious' => '9.00'},
   META_MERGE    => {
     'dynamic_config' => 0,
     'meta-spec'      => {version   => 2},

--- a/lib/Mojolicious/Plugin/OpenAPI/Parameters.pm
+++ b/lib/Mojolicious/Plugin/OpenAPI/Parameters.pm
@@ -127,9 +127,21 @@ sub _helper_parse_request_body {
 
   eval {
     $res->{value} //= $c->req->body_params->to_hash
-      if grep { $content_type eq $_ } qw(application/x-www-form-urlencoded multipart/form-data);
+      if $content_type =~ /^application\/x-www-form-urlencoded\s*(;|$)/i;
 
-    # Trying to use the already parsed json() or fallback to manually decoding the request
+    if ($content_type =~ /^multipart\/form-data\s*(;|$)/i) {
+      # body_params only includes non-file parameters, so we need to fetch the
+      # uploads separately and append them as Mojo::Upload objects.
+      #
+      # we also have to clone body_params before we merge in the file uploads
+      # because it's used as a cache by other helpers that expect it to
+      # only contain body parameters
+      my $params = $c->req->body_params->clone;
+      $params->append($_->name => $_) for @{$c->req->uploads};
+      $res->{value} = $params->to_hash;
+    }
+
+    # Try to use the already parsed json() or fallback to manually decoding the request
     # since it will make the eval {} fail on invalid json.
     $res->{value} //= $c->req->json // decode_json $c->req->body;
     1;

--- a/t/v3-file.t
+++ b/t/v3-file.t
@@ -23,6 +23,14 @@ $t->post_ok(
   form => {id => 1, image => {file => $image}}
 )->content_like(qr{"size"})->status_is(200);
 
+$image = Mojo::Asset::Memory->new->add_chunk('smileyface');
+$t->post_ok(
+  '/api/upload',
+  {Accept => 'application/json'},
+  form => {id => 1, image => [{file => $image}, 'unhappy face']}
+)->status_is(400)
+  ->json_is('/errors/0', {message => 'Expected string - got array.', path => '/body/image'});
+
 done_testing;
 
 __DATA__

--- a/t/v3-multipart.t
+++ b/t/v3-multipart.t
@@ -1,0 +1,222 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+
+use Mojolicious::Lite;
+
+post '/formdata' => sub {
+    my $c = shift;
+    $c->openapi->valid_input or return;
+
+    my $name = $c->param('name');
+
+    $c->render(json => {name => $name}, status => 200);
+  },
+  'formdata';
+
+post '/formdata_array' => sub {
+    my $c = shift;
+    $c->openapi->valid_input or return;
+
+    my $names = $c->req->body_params->every_param('name');
+
+    $c->render(json => {name => $names, count => scalar @$names}, status => 200);
+  },
+  'formdata_array';
+
+post '/upload' => sub {
+  my $c = shift;
+  $c->openapi->valid_input or return;
+
+  $c->render(openapi => {size => $c->req->upload('image')->size});
+  },
+  'upload';
+
+post '/upload_array' => sub {
+  my $c = shift;
+  $c->openapi->valid_input or return;
+
+  my $sizes = [map { $_->size } @{$c->req->every_upload('image')}];
+
+  $c->render(openapi => {size => $sizes, count => scalar @$sizes});
+  },
+  'upload_array';
+
+plugin OpenAPI => {url => 'data://main/openapi.yaml'};
+
+my $t = Test::Mojo->new;
+
+# Basic data validation
+
+$t->post_ok('/api/formdata', {'Content-Type' => 'application/json'}, json => {foo => 42})
+  ->status_is(400)
+  ->json_is('/errors/0', {message => 'Expected multipart/form-data - got application/json.', path => '/body'});
+
+$t->post_ok('/api/formdata', {'Content-Type' => 'multipart/form-data'}, form => {foo => 42})
+  ->status_is(400)
+  ->json_is('/errors/0', {message => 'Missing property.', path => '/body/name'});
+
+$t->post_ok('/api/formdata', {'Content-Type' => 'multipart/form-data'}, form => {name => 'John'})
+  ->status_is(200)
+  ->json_is('/name', 'John');
+
+$t->post_ok('/api/formdata', {'Content-Type' => 'multipart/form-data'}, form => {name => ['John', 'Jane']})
+  ->status_is(400)
+  ->json_is('/errors/0', {message => 'Expected string - got array.', path => '/body/name'});
+
+$t->post_ok('/api/formdata_array', {'Content-Type' => 'multipart/form-data'}, form => {name => 'John'})
+  ->status_is(200)
+  ->json_is('/name', ['John'])
+  ->json_is('/count', 1);
+
+$t->post_ok('/api/formdata_array', {'Content-Type' => 'multipart/form-data'}, form => {name => ['John', 'Jane']})
+  ->status_is(200)
+  ->json_is('/name', ['John', 'Jane'])
+  ->json_is('/count', 2);
+
+# File upload
+
+my $image = Mojo::Asset::Memory->new->add_chunk('smileyface');
+
+$t->post_ok('/api/upload', {'Content-Type' => 'multipart/form-data'}, form => {image => {file => $image}})
+  ->status_is(200)
+  ->json_has('/size');
+
+$t->post_ok('/api/upload', {'Content-Type' => 'multipart/form-data'}, form => {picture => {file => $image}})
+  ->status_is(400)
+  ->json_is('/errors/0', {message => 'Missing property.', path => '/body/image'});
+
+$t->post_ok('/api/upload', {'Content-Type' => 'multipart/form-data'}, form => {image => [{file => $image}, {file => $image}]})
+  ->status_is(400)
+  ->json_is('/errors/0', {message => 'Expected string - got array.', path => '/body/image'});
+
+$t->post_ok('/api/upload_array', {'Content-Type' => 'multipart/form-data'}, form => {image => {file => $image}})
+  ->status_is(200)
+  ->json_has('/size')
+  ->json_is('/count', 1);
+
+$t->post_ok('/api/upload_array', {'Content-Type' => 'multipart/form-data'}, form => {image => [{file => $image}, {file => $image}]})
+  ->status_is(200)
+  ->json_has('/size')
+  ->json_is('/count', 2);
+
+done_testing;
+
+__DATA__
+@@ openapi.yaml
+---
+openapi: 3.0.0
+info:
+  title: Upload test
+  version: 1.0.0
+servers:
+- url: http://example.com/api
+paths:
+  /formdata:
+    post:
+      x-mojo-name: formdata
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+      responses:
+        200:
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                required: [ name ]
+                properties:
+                  name:
+                    type: string
+  /formdata_array:
+    post:
+      x-mojo-name: formdata_array
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - name
+      responses:
+        200:
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                required: [ name ]
+                properties:
+                  name:
+                    type: array
+                    items:
+                      type: string
+                  count:
+                    type: integer
+  /upload:
+    post:
+      operationId: upload
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [ image ]
+              properties:
+                image:
+                  type: string
+                  format: binary
+      responses:
+        200:
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                required: [ size ]
+                properties:
+                  size:
+                    type: integer
+  /upload_array:
+    post:
+      operationId: upload_array
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [ image ]
+              properties:
+                image:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+      responses:
+        200:
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                required: [ size ]
+                properties:
+                  size:
+                    type: array
+                    items:
+                      type: integer
+                  count:
+                    type: integer


### PR DESCRIPTION
### Changes
- Fix resulting problems with `multipart/form-data` validation
  - Merge `body_params` with `uploads`, as Mojo likes to keep them separate so it can do magic stuff with `Mojo::Upload`

Now https://github.com/jhthorsen/json-validator/pull/288 is merged, json valdiator will accept `Mojo::Upload` as files.
    
Duplicate of https://github.com/jhthorsen/mojolicious-plugin-openapi/pull/266, but I couldn't get the original PR re-opened.

### Motivation
Currently, no validation is conducted on file uploads. The openapi spec has [an option for this](https://swagger.io/docs/specification/v3_0/describing-request-body/file-upload/).

### References
Requires https://github.com/jhthorsen/json-validator/pull/288